### PR TITLE
Header File Fixes and Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Copyright (C) 2000 - 2012 by [Emery Berger](http://www.cs.umass.edu/~emery)
 
 Please read [COPYING](heaplayers/COPYING) for licensing information.
 
-Heap Layers is distributed under the terms of the GNU General Public License.  
+Heap Layers is distributed under the terms of the GNU General Public License.
 
 **Commercial licenses are also available.**
 
@@ -24,7 +24,7 @@ a number of high-performance allocators, including [Hoard](http://www.hoard.org)
 For an introduction to Heap Layers, read the article [Policy-Based
 Memory Allocation](http://www.drdobbs.com/184402039), by Andrei
 Alexandrescu and Emery Berger. It's a good overview.
-    
+
 Heap Layers contains a number of ready-made heap components that can
 be plugged together with minimal effort, and the result is often
 faster than hand-built allocators. The PLDI 2001 paper [Composing
@@ -39,7 +39,7 @@ the Vmalloc package from AT&T. The OOPSLA 2002 paper [Reconsidering
 Custom Memory
 Allocation](http://www.cs.umass.edu/~emery/pubs/berger-oopsla2002.pdf)
 paper has more details.
-    
+
 Not only is Heap Layers much higher level and simpler to use, but
 its use of templates also improves performance. Heap Layers both
 eliminates the function call overhead imposed by Vmalloc layers and

--- a/heaplayers.h
+++ b/heaplayers.h
@@ -93,8 +93,6 @@ namespace HL {}
 #define ALLOCATION_STATS 0
 #endif
 
-
-
 #ifdef _MSC_VER
 // 4786: Disable warnings about long (> 255 chars) identifiers.
 // 4512: Disable warnings about assignment operators.
@@ -107,118 +105,6 @@ namespace HL {}
 #include "threads/all.h"
 #include "utility/all.h"
 #include "wrappers/all.h"
-
-
-
-//////////////////////////////
-
-
-#if 0
-
-
-#include "sassert.h"
-// #include "utility.h"		// convenient wrappers to replace C++ new & delete operators
-#include "dynarray.h"		// an array that grows by doubling
-#include "myhashmap.h"
-
-// Hiding machine dependencies.
-
-#include "mallocinfo.h"
-
-#include "cpuinfo.h"
-#include "timer.h"			// allows high-resolution timing across a wide range of platforms
-#include "guard.h"
-#include "fred.h"
-
-// Lock implementations.
-
-#include "spinlock.h"		// spin-then-yield
-
-#if defined(_WIN32)
-#include "winlock.h"		// critical-sections (i.e., for Windows only)
-#include "recursivelock.h"	// a wrapper for recursive locking
-#endif
-
-// Useful utilities.
-
-#include "uniqueheap.h"
-#include "tryheap.h"
-
-// Base heaps
-
-#include "zoneheap.h"		// a zone allocator (frees all memory when the heap goes out of scope)
-
-// Adapters
-
-#include "perclassheap.h"	// make a per-class heap
-
-
-// Freelist-like heaps ("allocation caches")
-// NB: All of these should be used for exactly one size class.
-
-#include "freelistheap.h"	// a free list. Never frees memory.
-//#include "fifofreelist.h"   // a FIFO free list.
-//#include "fifodlfreelist.h"  // a doubly-linked FIFO free list.
-#include "boundedfreelistheap.h"	// a free list with a bounded length. 
-
-
-#include "nullheap.h"
-#include "coalesceheap.h" // A chunk heap with coalescing.
-#include "coalesceableheap.h"
-
-// Utility heap layers
-
-#include "sizethreadheap.h"	// Adds size(ptr) & thread(ptr) methods
-#include "lockedheap.h"		// Code-locks a heap
-#include "checkheap.h"		// Raises assertions if malloc'ed objects aren't right.
-// #include "exceptionheap.h"	// Raise an exception if a malloc fails.
-
-#include "sanitycheckheap.h" // Check for multiple frees and mallocs of same locations.
-#include "ansiwrapper.h"     // Provide ANSI C like behavior for malloc (alignment, etc.)
-
-// Multi-threaded heaps
-//   hashes the thread id across a number of heaps
-
-//#include "phothreadheap.h"	// Private-heaps with ownership
-#include "threadheap.h"		// Pure-private heaps (sort of)
-
-// Generic heaps
-
-#include "segheap.h"		// A *very general* segregated fits allocator.
-
-// "Standard" heap layers
-
-#include "kingsleyheap.h"	// A power-of-two size class allocator,
-							// a la Chris Kingsley's BSD allocator.
-
-// "Top" heaps.
-#include "mallocheap.h"		// a thin wrapper around the system's malloc/free
-#include "mmapheap.h"		// a wrapper around the system's virtual memory system
-
-// the rest...
-
-#include "oneheap.h"
-#include "debugheap.h"
-#include "sizeheap.h"
-#include "addheap.h"
-#include "profileheap.h"
-#include "sizeownerheap.h"
-#include "hybridheap.h"
-#include "traceheap.h"
-#include "stlallocator.h"
-#include "adaptheap.h"
-#include "dllist.h"
-#include "dlheap.h"
-// #include "logheap.h"
-// #include "obstackheap.h"
-// #include "sbrkheap.h"
-// #include "xallocHeap.h" // 197.parser's heap
-
-#include "staticheap.h"
-
-#endif
-
-
 
 #ifdef _MSC_VER
 #pragma warning( pop )

--- a/heaps/all.h
+++ b/heaps/all.h
@@ -7,5 +7,3 @@
 #include "general/all.h"
 #include "top/all.h"
 #include "special/all.h"
-
-

--- a/heaps/buildingblock/adaptheap.h
+++ b/heaps/buildingblock/adaptheap.h
@@ -48,7 +48,7 @@ namespace HL {
     inline void * malloc (const size_t) {
       void * ptr = (Entry *) dict.get();
       if (ptr) {
-	assert (SuperHeap::getSize(ptr) >= sizeof(dict));
+        assert (SuperHeap::getSize(ptr) >= sizeof(dict));
       }
       return ptr;
     }
@@ -56,17 +56,17 @@ namespace HL {
     /// Deallocate the object (return to the dictionary).
     inline void free (void * ptr) {
       if (ptr) {
-	assert (SuperHeap::getSize(ptr) >= sizeof(dict));
-	Entry * entry = (Entry *) ptr;
-	dict.insert (entry);
+        assert (SuperHeap::getSize(ptr) >= sizeof(dict));
+        Entry * entry = (Entry *) ptr;
+        dict.insert (entry);
       }
     }
 
     /// Remove an object from the dictionary.
     inline int remove (void * ptr) {
       if (ptr) {
-	assert (SuperHeap::getSize(ptr) >= sizeof(dict));
-	dict.remove ((Entry *) ptr);
+        assert (SuperHeap::getSize(ptr) >= sizeof(dict));
+        dict.remove ((Entry *) ptr);
       }
       return 1;
     }
@@ -75,7 +75,7 @@ namespace HL {
     inline void clear (void) {
       Entry * ptr;
       while ((ptr = (Entry *) dict.get()) != NULL) {
-	SuperHeap::free (ptr);
+        SuperHeap::free (ptr);
       }
       dict.clear();
       SuperHeap::clear();

--- a/heaps/buildingblock/boundedfreelistheap.h
+++ b/heaps/buildingblock/boundedfreelistheap.h
@@ -5,10 +5,12 @@
 
 // Beware -- this is for one "size class" only!!
 
+#include <cstdlib>
+
 template <int numObjects, class Super>
 class BoundedFreeListHeap : public Super {
 public:
-  
+
   BoundedFreeListHeap (void)
     : nObjects (0),
     myFreeList (NULL)
@@ -29,7 +31,7 @@ public:
     }
     return ptr;
   }
-  
+
   inline void free (void * ptr) {
     if (nObjects < numObjects) {
       // Add this object to the free list.

--- a/heaps/buildingblock/chunkheap.h
+++ b/heaps/buildingblock/chunkheap.h
@@ -43,18 +43,18 @@ namespace HL {
 
     inline ChunkHeap (void)
       : buffer (NULL),
-	eob (NULL)
+      eob (NULL)
     {}
 
     inline void * malloc (const size_t sz) {
       void * ptr = buffer;
       buffer += sz;
       if (buffer <= eob) {
-	assert (eob != NULL);
-	assert ((size_t) (eob - (char *) ptr + 1) >= sz);
-	return ptr;
+        assert (eob != NULL);
+        assert ((size_t) (eob - (char *) ptr + 1) >= sz);
+        return ptr;
       }
-	  buffer -= sz;		// we didn't succeed, back up
+      buffer -= sz;		// we didn't succeed, back up
       return getMoreMemory(sz);
     }
 
@@ -75,19 +75,19 @@ namespace HL {
       size_t reqSize = (((sz-1) / ChunkSize) + 1) * ChunkSize;
       char * buf = (char *) SuperHeap::malloc (reqSize);
       if (buf == NULL) {
-	return NULL;
+        return NULL;
       }
       // If the current end of buffer is not the same as the new buffer,
       // reset the buffer pointer.
       if (eob != buf) {
-	buffer = buf;
+        buffer = buf;
       }
-	  else {
-		  // we still have a bit leftover at the end of previous buffer
-		  reqSize += eob - buffer;
-	  }
+      else {
+        // we still have a bit leftover at the end of previous buffer
+        reqSize += eob - buffer;
+      }
       eob = buffer + reqSize;
-    
+
       void * ptr = buffer;
       buffer += sz;
       return ptr;

--- a/heaps/buildingblock/coalesceheap.h
+++ b/heaps/buildingblock/coalesceheap.h
@@ -48,12 +48,12 @@ namespace HL {
     {
       void * ptr = super::malloc (sz);
       if (ptr != NULL) {
-	super::markInUse (ptr);
-	void * splitPiece = split (ptr, sz);
-	if (splitPiece != NULL) {
-	  super::markFree (splitPiece);
-	  super::free (splitPiece);
-	}
+        super::markInUse (ptr);
+        void * splitPiece = split (ptr, sz);
+        if (splitPiece != NULL) {
+          super::markFree (splitPiece);
+          super::free (splitPiece);
+        }
       }
       return ptr;
     }
@@ -63,9 +63,9 @@ namespace HL {
     {
       // Try to coalesce this object with its predecessor & successor.
       if ((super::getNext(super::getPrev(ptr)) != ptr) || (super::getPrev(super::getNext(ptr)) != ptr)) {
-	// We're done with this object.
-	super::free (ptr);
-	return;
+        // We're done with this object.
+        super::free (ptr);
+        return;
       }
       assert (super::getPrev(super::getNext(ptr)) == ptr);
       // Try to coalesce with the previous object..
@@ -74,16 +74,16 @@ namespace HL {
       assert (prev != ptr);
 
       if (super::isPrevFree(ptr)) {
-	assert (super::isFree(prev));
-	super::remove (prev);
-	coalesce (prev, ptr);
-	ptr = prev;
+        assert (super::isFree(prev));
+        super::remove (prev);
+        coalesce (prev, ptr);
+        ptr = prev;
       }
       if (super::isFree(next)) {
-	super::remove (next);
-	coalesce (ptr, next);
+        super::remove (next);
+        coalesce (ptr, next);
       }
-	
+
       super::markFree (ptr);
 
       // We're done with this object.
@@ -110,21 +110,21 @@ namespace HL {
       // We split aggressively (for now; this could be a parameter).
       const size_t actualSize = super::getSize(obj);
       if (actualSize - requestedSize >= sizeof(typename super::Header) + sizeof(double)) {
-	// Split the object.
-	super::setSize(obj, requestedSize);
-	void * splitPiece = (char *) obj + requestedSize + sizeof(typename super::Header);
-	super::makeObject ((void *) super::getHeader(splitPiece),
-			   requestedSize,
-			   actualSize - requestedSize - sizeof(typename super::Header));
-	assert (!super::isFree(splitPiece));
-	// Now that we have a new successor (splitPiece), we need to
-	// mark obj as in use.
-	(super::getHeader(splitPiece))->markPrevInUse();
-	assert (super::getSize(splitPiece) >= sizeof(double));
-	assert (super::getSize(obj) >= requestedSize);
-	return splitPiece;
+        // Split the object.
+        super::setSize(obj, requestedSize);
+        void * splitPiece = (char *) obj + requestedSize + sizeof(typename super::Header);
+        super::makeObject ((void *) super::getHeader(splitPiece),
+          requestedSize,
+          actualSize - requestedSize - sizeof(typename super::Header));
+        assert (!super::isFree(splitPiece));
+        // Now that we have a new successor (splitPiece), we need to
+        // mark obj as in use.
+        (super::getHeader(splitPiece))->markPrevInUse();
+        assert (super::getSize(splitPiece) >= sizeof(double));
+        assert (super::getSize(obj) >= requestedSize);
+        return splitPiece;
       } else {
-	return NULL;
+        return NULL;
       }
     }
 

--- a/heaps/buildingblock/freelistheap.h
+++ b/heaps/buildingblock/freelistheap.h
@@ -31,7 +31,7 @@
  * @class FreelistHeap
  * @brief Manage freed memory on a linked list.
  * @warning This is for one "size class" only.
- * 
+ *
  * Note that the linked list is threaded through the freed objects,
  * meaning that such objects must be at least the size of a pointer.
  */
@@ -48,21 +48,21 @@ namespace HL {
   template <class SuperHeap>
   class FreelistHeap : public SuperHeap {
   public:
-  
+
     inline void * malloc (size_t sz) {
       // Check the free list first.
       void * ptr = _freelist.get();
       // If it's empty, get more memory;
       // otherwise, advance the free list pointer.
       if (ptr == 0) {
-	ptr = SuperHeap::malloc (sz);
+        ptr = SuperHeap::malloc (sz);
       }
       return ptr;
     }
-  
+
     inline void free (void * ptr) {
       if (ptr == 0) {
-	return;
+        return;
       }
       _freelist.insert (ptr);
     }
@@ -70,7 +70,7 @@ namespace HL {
     inline void clear (void) {
       void * ptr;
       while ((ptr = _freelist.get())) {
-	SuperHeap::free (ptr);
+        SuperHeap::free (ptr);
       }
     }
 

--- a/heaps/combining/hybridheap.h
+++ b/heaps/combining/hybridheap.h
@@ -29,8 +29,7 @@
 
 #include <assert.h>
 
-#include "utility/sassert.h"
-#include "utility/gcd.h"
+#include <heaplayers.h>
 
 /**
  * @class HybridHeap
@@ -53,28 +52,28 @@ namespace HL {
     MALLOC_FUNCTION INLINE void * malloc (size_t sz) {
       void * ptr;
       if (sz <= BigSize) {
-	ptr = SmallHeap::malloc (sz);
+        ptr = SmallHeap::malloc (sz);
       } else {
-	ptr = slowPath (sz);
+        ptr = slowPath (sz);
       }
       assert (SmallHeap::getSize(ptr) >= sz);
       assert ((size_t) ptr % Alignment == 0);
       return ptr;
     }
-  
+
     inline void free (void * ptr) {
       if (SmallHeap::getSize(ptr) <= BigSize) {
-	SmallHeap::free (ptr);
+        SmallHeap::free (ptr);
       } else {
-	bm.free (ptr);
+        bm.free (ptr);
       }
     }
-  
+
     inline void clear (void) {
       bm.clear();
       SmallHeap::clear();
     }
-  
+
 
   private:
 

--- a/heaps/combining/strictsegheap.h
+++ b/heaps/combining/strictsegheap.h
@@ -37,7 +37,7 @@
 /**
  * @class StrictSegHeap
  * @brief A "strict" segregated-fits collection of (homogeneous) heaps.
- * 
+ *
  * One extra heap is used for objects that are "too big".  Unlike
  * SegHeap, StrictSegHeap does not perform splitting to satisfy memory
  * requests. If no memory is available from the appropriate bin,
@@ -71,19 +71,19 @@ namespace HL {
     void freeAll (void) {
       int i;
       for (i = 0; i < NumBins; i++) {
-	const size_t sz = class2size(i);
-	void * ptr;
-	while ((ptr = SuperHeap::myLittleHeap[i].malloc (sz)) != NULL) {
-	  SuperHeap::bigheap.free (ptr);
-	}
+        const size_t sz = class2size(i);
+        void * ptr;
+        while ((ptr = SuperHeap::myLittleHeap[i].malloc (sz)) != NULL) {
+          SuperHeap::bigheap.free (ptr);
+        }
       }
       for (int j = 0; j < SuperHeap::NUM_ULONGS; j++) {
-	SuperHeap::binmap[j] = 0;
+        SuperHeap::binmap[j] = 0;
       }
       SuperHeap::memoryHeld = 0;
     }
 
-  
+
     /**
      * Malloc from exactly one available size.
      * (don't look in every small heap, as in SegHeap).
@@ -97,12 +97,12 @@ namespace HL {
       assert (realSize >= sz);
 
       if (realSize <= SuperHeap::maxObjectSize) {
-	assert (sizeClass >= 0);
-	assert (sizeClass < NumBins);
-	ptr = SuperHeap::myLittleHeap[sizeClass].malloc (realSize);
+        assert (sizeClass >= 0);
+        assert (sizeClass < NumBins);
+        ptr = SuperHeap::myLittleHeap[sizeClass].malloc (realSize);
       }
       if (!ptr) {
-	ptr = SuperHeap::bigheap.malloc (realSize);
+        ptr = SuperHeap::bigheap.malloc (realSize);
       }
       return ptr;
     }
@@ -110,22 +110,22 @@ namespace HL {
     inline void free (void * ptr) {
       const size_t objectSize = SuperHeap::getSize(ptr);
       if (objectSize > SuperHeap::maxObjectSize) {
-	SuperHeap::bigheap.free (ptr);
+        SuperHeap::bigheap.free (ptr);
       } else {
-	int objectSizeClass = size2class(objectSize);
-	assert (objectSizeClass >= 0);
-	assert (objectSizeClass < NumBins);
+        int objectSizeClass = size2class(objectSize);
+        assert (objectSizeClass >= 0);
+        assert (objectSizeClass < NumBins);
 
-	// Put the freed object into the right sizeclass heap.
+        // Put the freed object into the right sizeclass heap.
 
-	// Ensure that the bin that we are going to put it in is for
-	// objects that are no bigger than the actual size of the
-	// object.
-	while (class2size(objectSizeClass) > objectSize)
-	  objectSizeClass--;
+        // Ensure that the bin that we are going to put it in is for
+        // objects that are no bigger than the actual size of the
+        // object.
+        while (class2size(objectSizeClass) > objectSize)
+          objectSizeClass--;
 
-	SuperHeap::myLittleHeap[objectSizeClass].free (ptr);
-	SuperHeap::memoryHeld += objectSize;
+        SuperHeap::myLittleHeap[objectSizeClass].free (ptr);
+        SuperHeap::memoryHeld += objectSize;
       }
     }
 

--- a/heaps/combining/tryheap.h
+++ b/heaps/combining/tryheap.h
@@ -27,26 +27,28 @@
 #ifndef HL_TRYHEAP_H
 #define HL_TRYHEAP_H
 
+#include <cstddef>
+
 namespace HL {
 
   template <class Heap1, class Heap2>
   class TryHeap : public Heap2 {
   public:
-    
+
     TryHeap (void)
     {}
-    
+
     inline void * malloc (size_t sz) {
       void * ptr = heap1.malloc (sz);
       if (ptr == NULL)
-	ptr = Heap2::malloc (sz);
+        ptr = Heap2::malloc (sz);
       return ptr;
     }
-    
+
     inline void free (void * ptr) {
       heap1.free (ptr);
     }
-    
+
   private:
     Heap1 heap1;
   };

--- a/heaps/debug/checkheap.h
+++ b/heaps/debug/checkheap.h
@@ -25,25 +25,25 @@ namespace HL {
     enum { RECEIVED_AN_UNALIGNED_OBJECT_FROM_MALLOC = 0 };
 
   public:
-    
+
     inline void * malloc (size_t sz) {
       void * addr = SuperHeap::malloc (sz);
 #if !defined(NDEBUG)
 
       // Check for null (this should in general not happen).
       if (addr == NULL) {
-	assert (RECEIVED_A_NULL_OBJECT_FROM_MALLOC);
-	printf ("RECEIVED_A_NULL_OBJECT_FROM_MALLOC\n");
-	abort();
+        assert (RECEIVED_A_NULL_OBJECT_FROM_MALLOC);
+        printf ("RECEIVED_A_NULL_OBJECT_FROM_MALLOC\n");
+        abort();
       }
       // Ensure object size is correct.
       assert (SuperHeap::getSize(addr) >= sz);
 
       // Check alignment.
       if ((unsigned long) addr % SuperHeap::Alignment != 0) {
-	assert (RECEIVED_AN_UNALIGNED_OBJECT_FROM_MALLOC);
-	printf ("RECEIVED_AN_UNALIGNED_OBJECT_FROM_MALLOC\n");
-	abort();
+        assert (RECEIVED_AN_UNALIGNED_OBJECT_FROM_MALLOC);
+        printf ("RECEIVED_AN_UNALIGNED_OBJECT_FROM_MALLOC\n");
+        abort();
       }
 
       // Wipe out the old contents.
@@ -59,7 +59,7 @@ namespace HL {
 #endif
       SuperHeap::free (ptr);
     }
-    
+
   };
 
 }

--- a/heaps/debug/debugheap.h
+++ b/heaps/debug/debugheap.h
@@ -29,13 +29,13 @@ namespace HL {
       void * ptr;
       ptr = Super::malloc (sz + sizeof(unsigned long));
       for (unsigned long i = 0; i < sz; i++) {
-	((char *) ptr)[i] = 'A';
+        ((char *) ptr)[i] = 'A';
       }
       *((unsigned long *) ((char *) ptr + sz)) = (unsigned long) CANARY;
       assert (Super::getSize(ptr) >= sz);
       return ptr;
     }
-  
+
     // Fill with F's.
     inline void free (void * ptr) {
       char * b = (char *) ptr;
@@ -43,10 +43,10 @@ namespace HL {
       // Check for the canary.
       unsigned long storedCanary = *((unsigned long *) b + sz - sizeof(unsigned long));
       if (storedCanary != CANARY) {
-	abort();
+        abort();
       }
       for (unsigned int i = 0; i < sz; i++) {
-	((char *) ptr)[i] = freeChar;
+        ((char *) ptr)[i] = freeChar;
       }
       Super::free (ptr);
     }

--- a/heaps/debug/logheap.h
+++ b/heaps/debug/logheap.h
@@ -47,7 +47,7 @@ namespace HL {
 
     void writeLog (void) {
       {
-	ofstream outfile (filename, ios_base::app);
+        ofstream outfile (filename, ios_base::app);
       }
       write(filename);
     }
@@ -59,18 +59,18 @@ namespace HL {
 
     int append (const Obj& o) {
       if (numEntries < MAX_ENTRIES) {
-	entries[numEntries] = o;
-	numEntries++;
-	return 1;
+        entries[numEntries] = o;
+        numEntries++;
+        return 1;
       } else {
-	return 0;
+        return 0;
       }
     }
-    
+
     void write (char * fname) {
       ofstream outfile (fname, ios_base::app);
       for (int i = 0; i < numEntries; i++) {
-	outfile << entries[i] << endl;
+        outfile << entries[i] << endl;
       }
     }
 
@@ -93,14 +93,14 @@ namespace HL {
     inline void * malloc (size_t sz) {
       void * ptr = SuperHeap::malloc (sz);
       if (!allDone) {
-	MemoryRequest m;
-	m.malloc (ptr, sz);
-	if (!log.append (m)) {
-	  allDone = true;
-	  log.dump();
-	  log.append(m);
-	  allDone = false;
-	}
+        MemoryRequest m;
+        m.malloc (ptr, sz);
+        if (!log.append (m)) {
+          allDone = true;
+          log.dump();
+          log.append(m);
+          allDone = false;
+        }
       }
       return ptr;
     }
@@ -112,9 +112,9 @@ namespace HL {
 
     inline void free (void * ptr) {
       if (!allDone) {
-	MemoryRequest m;
-	m.free (ptr);
-	log.append (m);
+        MemoryRequest m;
+        m.free (ptr);
+        log.append (m);
       }
       SuperHeap::free (ptr);
     }
@@ -125,13 +125,13 @@ namespace HL {
     public:
 
       MemoryRequest (void)
-	:
+        :
 #if 0
-	_sec (LONG_MAX),
-	_usec (LONG_MAX),
+        _sec (LONG_MAX),
+        _usec (LONG_MAX),
 #endif
-	_size (0),
-	_address (INVALID)
+        _size (0),
+        _address (INVALID)
       {}
 
       enum { FREE_OP = 0,
@@ -144,54 +144,55 @@ namespace HL {
       };
 
       friend std::ostream& operator<< (std::ostream& os, MemoryRequest& m) {
-	switch (m.getType()) {
-	case FREE_OP:
-	  os << "F\t" << (void *) m.getAddress();
-	  break;
-	case MALLOC_OP:
-	  os << "M\t" << m.getSize() << "\t" << (void *) m.getAddress();
-	  break;
-	default:
-	  abort();
-	}
-	return os;
+        switch (m.getType()) {
+        case FREE_OP:
+          os << "F\t" << (void *) m.getAddress();
+          break;
+        case MALLOC_OP:
+          os << "M\t" << m.getSize() << "\t" << (void *) m.getAddress();
+          break;
+        default:
+          abort();
+        }
+
+        return os;
       }
 
       void malloc (void * addr,
 		   size_t sz)
       {
-	assert ((((unsigned long) addr) & 7) == 0);
-	_size = sz;
-	_address = (unsigned long) addr | MALLOC_OP;
-	//      markTime (_sec, _usec);
-	// printf ("malloc %d (%f)\n", sz, getTime());
+        assert ((((unsigned long) addr) & 7) == 0);
+        _size = sz;
+        _address = (unsigned long) addr | MALLOC_OP;
+        //      markTime (_sec, _usec);
+        // printf ("malloc %d (%f)\n", sz, getTime());
       }
 
 
       void free (void * addr)
       {
-	assert ((((unsigned long) addr) & 7) == 0);
-	_address = (unsigned long) addr | FREE_OP;
-	//      markTime (_sec, _usec);
-	// printf ("free %d (%f)\n", _address, getTime());
+        assert ((((unsigned long) addr) & 7) == 0);
+        _address = (unsigned long) addr | FREE_OP;
+        //      markTime (_sec, _usec);
+        // printf ("free %d (%f)\n", _address, getTime());
       }
 
 
       void allocate (int sz)
       {
-	_address = ALLOCATE_OP;
-	_size = sz;
-	markTime (_sec, _usec);
-	// printf ("allocate %d (%f)\n", sz, getTime());
+        _address = ALLOCATE_OP;
+        _size = sz;
+        markTime (_sec, _usec);
+        // printf ("allocate %d (%f)\n", sz, getTime());
       }
 
 
       void deallocate (int sz)
       {
-	_address = DEALLOCATE_OP;
-	_size = sz;
-	markTime (_sec, _usec);
-	// printf ("allocate %d (%f)\n", sz, getTime());
+        _address = DEALLOCATE_OP;
+        _size = sz;
+        markTime (_sec, _usec);
+        // printf ("allocate %d (%f)\n", sz, getTime());
       }
 
 
@@ -200,70 +201,70 @@ namespace HL {
       {
 #if 0
 #ifdef __SVR4 // Solaris
-	hrtime_t t;
-	t = gethrtime();
-	sec = *((long *) &t);
-	usec = *((long *) &t + 1);
+        hrtime_t t;
+        t = gethrtime();
+        sec = *((long *) &t);
+        usec = *((long *) &t + 1);
 #else
-	struct timeval tv;
-	struct timezone tz;
-	gettimeofday (&tv, &tz);
-	sec = tv.tv_sec;
-	usec = tv.tv_usec;
+        struct timeval tv;
+        struct timezone tz;
+        gettimeofday (&tv, &tz);
+        sec = tv.tv_sec;
+        usec = tv.tv_usec;
 #endif
 #endif
       }
 
       int getType (void) {
-	return _address & 7;
+        return _address & 7;
       }
 
       int getAllocated (void) {
-	return _size;
+        return _size;
       }
 
       int getDeallocated (void) {
-	return _size;
+        return _size;
       }
 
       unsigned long getAddress (void) {
-	return _address & ~7;
+        return _address & ~7;
       }
 
       int getSize (void) {
-	return _size;
+        return _size;
       }
 
 #if 0
       double getTime (void) {
-	return (double) _sec + (double) _usec / 1000000.0;
+        return (double) _sec + (double) _usec / 1000000.0;
       }
 
       long getSeconds (void) {
-	return _sec;
+        return _sec;
       }
 
       long getUseconds (void) {
-	return _usec;
+        return _usec;
       }
 
       friend int operator< (MemoryRequest& m, MemoryRequest& n) {
-	return ((m._sec < n._sec)
-		|| ((m._sec == n._sec)
-		    && (m._usec < n._usec)));
+        return ((m._sec < n._sec)
+          || ((m._sec == n._sec)
+          && (m._usec < n._usec)));
       }
 
       friend int operator== (MemoryRequest& m, MemoryRequest& n) {
-	return ((m._sec == n._sec) && (m._usec == n._usec));
+        return ((m._sec == n._sec) && (m._usec == n._usec));
       }
 #endif
 
     private:
-      int	_size;     	// in bytes 
-      unsigned long _address;  // The address returned by malloc/realloc   
+      int	_size;     	// in bytes
+      unsigned long _address;  // The address returned by malloc/realloc
 #if 1
-      long	_sec;      	// seconds as returned by gettimeofday      
-      long	_usec;     	// microseconds as returned by gettimeofday 
+      long	_sec;      	// seconds as returned by gettimeofday
+      long	_usec;     	// microseconds as returned by gettimeofday
 #endif
     };
 

--- a/heaps/debug/sanitycheckheap.h
+++ b/heaps/debug/sanitycheckheap.h
@@ -39,10 +39,10 @@ namespace HL {
 
     /// A map of pointers to objects and their allocated sizes.
     typedef std::map<void *, size_t, localComparator, localAllocator> mapType;
-  
+
     /// A freed object has a special size, -1.
     enum { FREED = -1 };
-  
+
     /**
      * @brief "Error messages", used in asserts.
      * These must all equal zero.
@@ -50,13 +50,13 @@ namespace HL {
     enum { MALLOC_RETURNED_ALLOCATED_OBJECT = 0,
 	   FREE_CALLED_ON_OBJECT_I_NEVER_ALLOCATED = 0,
 	   FREE_CALLED_TWICE_ON_SAME_OBJECT = 0 };
-  
+
   public:
 
     inline void * malloc (size_t sz) {
       void * ptr = SuperHeap::malloc (sz);
       if (ptr == NULL) {
-	return NULL;
+        return NULL;
       }
       // Fill the space with a known value.
       memset (ptr, 'A', sz);
@@ -65,20 +65,20 @@ namespace HL {
       // Look for this object in the map of allocated objects.
       i = allocatedObjects.find (ptr);
       if (i == allocatedObjects.end()) {
-	// We didn't find it (this is good).
-	// Add the tuple (ptr, sz).
-	allocatedObjects.insert (std::pair<void *, int>(ptr, sz));
+        // We didn't find it (this is good).
+        // Add the tuple (ptr, sz).
+        allocatedObjects.insert (std::pair<void *, int>(ptr, sz));
       } else {
-	// We found it.
-	// It really should have been freed.
-	if ((*i).second != FREED) {
-	  // This object is still in use!
-	  assert ( MALLOC_RETURNED_ALLOCATED_OBJECT );
-	  return NULL;
-	} else {
-	  // This object has been freed. Mark it as allocated.
-	  (*i).second = sz;
-	}
+      // We found it.
+      // It really should have been freed.
+        if ((*i).second != FREED) {
+          // This object is still in use!
+          assert ( MALLOC_RETURNED_ALLOCATED_OBJECT );
+          return NULL;
+        } else {
+          // This object has been freed. Mark it as allocated.
+          (*i).second = sz;
+        }
       }
       return ptr;
     }
@@ -88,14 +88,14 @@ namespace HL {
       mapType::iterator i;
       i = allocatedObjects.find (ptr);
       if (i == allocatedObjects.end()) {
-	assert ( FREE_CALLED_ON_OBJECT_I_NEVER_ALLOCATED );
-	return;
+        assert ( FREE_CALLED_ON_OBJECT_I_NEVER_ALLOCATED );
+        return;
       }
       // We found the object. It should not have been freed already.
       if ((*i).second == FREED) {
-	// Oops, this object WAS freed before.
-	assert ( FREE_CALLED_TWICE_ON_SAME_OBJECT );
-	return;
+        // Oops, this object WAS freed before.
+        assert ( FREE_CALLED_TWICE_ON_SAME_OBJECT );
+        return;
       }
       // Fill the space with a known value.
       memset (ptr, 'F', (*i).second);

--- a/heaps/debug/statsheap.h
+++ b/heaps/debug/statsheap.h
@@ -4,6 +4,7 @@
 #define HL_STATS_H
 
 #include <map>
+#include <cassert>
 
 namespace HL {
 
@@ -32,8 +33,8 @@ namespace HL {
       mapType::iterator i;
       i = allocatedObjects.find (ptr);
       if (i == allocatedObjects.end()) {
-	// oops -- called free on object i didn't allocate.
-	assert (0);
+        // oops -- called free on object i didn't allocate.
+        assert (0);
       }
       inUse -= (*i).second;
       allocatedObjects.erase (i);
@@ -60,15 +61,15 @@ namespace HL {
   public:
     AllocatedHeap (void)
       : allocated (0),
-	maxAllocated (0)
+      maxAllocated (0)
     {}
     void * malloc (size_t sz) {
       void * ptr = SuperHeap::malloc (sz);
       if (ptr != NULL) {
-	allocated += SuperHeap::getSize(ptr);
-	if (maxAllocated < allocated) {
-	  maxAllocated = allocated;
-	}
+        allocated += SuperHeap::getSize(ptr);
+        if (maxAllocated < allocated) {
+          maxAllocated = allocated;
+        }
       }
       return ptr;
     }
@@ -77,7 +78,7 @@ namespace HL {
       allocated -= SuperHeap::getSize(ptr);
       SuperHeap::free (ptr);
     }
-    
+
     int getAllocated (void) const {
       return allocated;
     }

--- a/heaps/general/dlheap.h
+++ b/heaps/general/dlheap.h
@@ -39,12 +39,13 @@
 #include "utility/dllist.h"
 #include "utility/sllist.h"
 #include "heaps/objectrep/coalesceableheap.h"
+#include "heaps/buildingblock/coalesceheap.h"
 
 #ifndef TRUE
 #define TRUE 1
 #define FALSE 0
 #endif
- 
+
 
 /**
  * @class CoalesceableMmapHeap
@@ -152,12 +153,12 @@ public:
       const size_t actualSize = super::getSize(ptr);
       inUse += actualSize;
       if (inUse > maxInUse) {
-	maxInUse = inUse;
-	threshold = 16384 + maxInUse / 2;
+        maxInUse = inUse;
+        threshold = 16384 + maxInUse / 2;
       }
 #if 0
       if (freed < 0) {
-	freed = 0;
+        freed = 0;
       }
 #endif
     }
@@ -175,10 +176,10 @@ public:
     void * ptr = super::malloc (sz);
     if (ptr != NULL) {
       if (sz < MIN_LARGE_SIZE) {
-	freed -= getSize(ptr);
-	if (freed < 0) {
-	  freed = 0;
-	}
+        freed -= getSize(ptr);
+        if (freed < 0) {
+          freed = 0;
+        }
       }
     }
     return ptr;
@@ -192,7 +193,7 @@ public:
     super::free (ptr);
     if (super::getMemoryHeld() > threshold) {
       super::freeAll();
-    }		
+    }
   }
 
 private:
@@ -207,17 +208,17 @@ private:
 
   // How many bytes have been freed (whose requests were below MIN_LARGE_SIZE).
   //  int freed;
-  
+
   /// Should we free all in the superheap on the next malloc?
   bool freeAllNextMalloc;
-  
+
 #else
   inline Threshold (void)
   {}
-  
+
   inline void * malloc (const size_t sz) {
     if ((getMemoryHeld() > ThresholdBytes) ||
-	((sz >= MIN_LARGE_SIZE) && (getMemoryHeld() >= sz))) {
+      ((sz >= MIN_LARGE_SIZE) && (getMemoryHeld() >= sz))) {
       super::freeAll();
     }
     return super::malloc (sz);
@@ -234,27 +235,27 @@ private:
 namespace DLBigHeapNS
 {
   const size_t bins[] = {8U, 16U, 24U, 32U, 40U, 48U, 56U, 64U, 72U, 80U, 88U,
-			 96U, 104U, 112U, 120U, 128U, 136U, 144U, 152U, 160U,
-			 168U, 176U, 184U, 192U, 200U, 208U, 216U, 224U, 232U,
-			 240U, 248U, 256U, 264U, 272U, 280U, 288U, 296U, 304U,
-			 312U, 320U, 328U, 336U, 344U, 352U, 360U, 368U, 376U,
-			 384U, 392U, 400U, 408U, 416U, 424U, 432U, 440U, 448U,
-			 456U, 464U, 472U, 480U, 488U, 496U, 504U, 512U, 576U,
-			 640U, 704U, 768U, 832U, 896U, 960U, 1024U, 1088U, 1152U,
-			 1216U, 1280U, 1344U, 1408U, 1472U, 1536U, 1600U, 1664U,
-			 1728U, 1792U, 1856U, 1920U, 1984U, 2048U, 2112U, 2560U,
-			 3072U, 3584U,
-			 4096U, 4608U, 5120U, 5632U, 6144U, 6656U, 7168U, 7680U,
-			 8192U, 8704U, 9216U, 9728U, 10240U, 10752U, 12288U,
-			 16384U, 20480U, 24576U, 28672U, 32768U, 36864U, 40960U,
-			 65536U, 98304U, 131072U, 163840U, 262144U, 524288U,
-			 1048576U, 2097152U, 4194304U, 8388608U, 16777216U,
-			 33554432U, 67108864U, 134217728U, 268435456U, 536870912U,
-			 1073741824U, 2147483648U  };
+                         96U, 104U, 112U, 120U, 128U, 136U, 144U, 152U, 160U,
+                         168U, 176U, 184U, 192U, 200U, 208U, 216U, 224U, 232U,
+                         240U, 248U, 256U, 264U, 272U, 280U, 288U, 296U, 304U,
+                         312U, 320U, 328U, 336U, 344U, 352U, 360U, 368U, 376U,
+                         384U, 392U, 400U, 408U, 416U, 424U, 432U, 440U, 448U,
+                         456U, 464U, 472U, 480U, 488U, 496U, 504U, 512U, 576U,
+                         640U, 704U, 768U, 832U, 896U, 960U, 1024U, 1088U, 1152U,
+                         1216U, 1280U, 1344U, 1408U, 1472U, 1536U, 1600U, 1664U,
+                         1728U, 1792U, 1856U, 1920U, 1984U, 2048U, 2112U, 2560U,
+                         3072U, 3584U,
+                         4096U, 4608U, 5120U, 5632U, 6144U, 6656U, 7168U, 7680U,
+                         8192U, 8704U, 9216U, 9728U, 10240U, 10752U, 12288U,
+                         16384U, 20480U, 24576U, 28672U, 32768U, 36864U, 40960U,
+                         65536U, 98304U, 131072U, 163840U, 262144U, 524288U,
+                         1048576U, 2097152U, 4194304U, 8388608U, 16777216U,
+                         33554432U, 67108864U, 134217728U, 268435456U, 536870912U,
+                         1073741824U, 2147483648U  };
 
   enum { NUMBINS = sizeof(bins) / sizeof(size_t) };
   enum { BIG_OBJECT = 2147483648U };
-  
+
   /**
    * @brief Compute the log base two.
    * @param sz The value we want the log of.
@@ -268,9 +269,9 @@ namespace DLBigHeapNS
     }
     return c;
   }
-  
+
   inline int getSizeClass (const size_t sz);
-  
+
   inline size_t getClassSize (const int i) {
     assert (i >= 0);
     assert (i < NUMBINS);
@@ -279,17 +280,17 @@ namespace DLBigHeapNS
       return ((size_t) ((i+1) << 3));
     } else {
       return
-	(i < 89) ? ((size_t) ((i - 55) << 6)) :
-	(i < 106) ? ((size_t) ((i - 84) << 9)) :
-	(i < 114) ? ((size_t) ((i - 103) << 12)) :
-	(i < 118) ? ((size_t) ((i - 112) << 15)) :
-	(i < 120) ? ((size_t) ((i - 117) * 262144)) :
-	(i < 122) ? ((size_t) ((i - 119) * 1048576)) :
-	(i < 124) ? ((size_t) ((i - 121) * 4 * 1048576)) :
-	(i < 126) ? ((size_t) ((i - 123) * 16 * 1048576)) :
-	(i < 128) ? ((size_t) ((i - 125) * 64 * 1048576)) :
-	(i < 130) ? ((size_t) ((i - 127) * 256 * 1048576)) :
-	((size_t) ((i - 129) * 1024 * 1048576));
+        (i < 89) ? ((size_t) ((i - 55) << 6)) :
+        (i < 106) ? ((size_t) ((i - 84) << 9)) :
+        (i < 114) ? ((size_t) ((i - 103) << 12)) :
+        (i < 118) ? ((size_t) ((i - 112) << 15)) :
+        (i < 120) ? ((size_t) ((i - 117) * 262144)) :
+        (i < 122) ? ((size_t) ((i - 119) * 1048576)) :
+        (i < 124) ? ((size_t) ((i - 121) * 4 * 1048576)) :
+        (i < 126) ? ((size_t) ((i - 123) * 16 * 1048576)) :
+        (i < 128) ? ((size_t) ((i - 125) * 64 * 1048576)) :
+        (i < 130) ? ((size_t) ((i - 127) * 256 * 1048576)) :
+        ((size_t) ((i - 129) * 1024 * 1048576));
     }
 #else
 #if 0
@@ -307,35 +308,35 @@ namespace DLBigHeapNS
       return sz1 >> 3;
     } else {
 #if 0
-      //		size_t sz1 = sz - 1;
+      // size_t sz1 = sz - 1;
       sz1 >>= 6;
       if (sz1 <= 32) {
-	return 56 + sz1;
+        return 56 + sz1;
       }
       sz1 >>= 3;
       if (sz1 <= 20) {
-	return 91 + sz1;
+        return 91 + sz1;
       }
       sz1 >>= 3;
       if (sz1 <= 10) {
-	return 110 - 6 + sz1;
+        return 110 - 6 + sz1;
       }
       sz1 >>= 3;
       if (sz1 <= 4) {
-	return 119 - 6 + sz1;
+        return 119 - 6 + sz1;
       }
       sz1 >>= 3;
       if (sz1 <= 2) {
-	return 124 - 6 + sz1;
+        return 124 - 6 + sz1;
       }
       return 125 - 6 + log2(sz1 >> 2);
 #else
       const size_t sz1 = sz - 1;
-      return (((sz1 >>  6) <= 32)?  56 + (sz1 >>  6): 
-	      ((sz1 >>  9) <= 20)?  91 + (sz1 >>  9):
-	      ((sz1 >> 12) <= 10)? 110 - 6 + (sz1 >> 12):
-	      ((sz1 >> 15) <=  4)? 119 - 6 + (sz1 >> 15):
-	      ((sz1 >> 18) <=  2)? 124 - 6 + (sz1 >> 18): 126 - 6 + log2(sz1>>19));
+      return (((sz1 >>  6) <= 32)?  56 + (sz1 >>  6):
+              ((sz1 >>  9) <= 20)?  91 + (sz1 >>  9):
+              ((sz1 >> 12) <= 10)? 110 - 6 + (sz1 >> 12):
+              ((sz1 >> 15) <=  4)? 119 - 6 + (sz1 >> 15):
+              ((sz1 >> 18) <=  2)? 124 - 6 + (sz1 >> 18): 126 - 6 + log2(sz1>>19));
 #endif
     }
   }
@@ -372,26 +373,26 @@ namespace DLSmallHeapNS {
 
 template <class super>
 class DLBigHeapType :
-  public 
+  public
 CoalesceHeap<RequireCoalesceable<
   SegHeap<Kingsley::NUMBINS,
-	  Kingsley::size2Class,
-	  Kingsley::class2Size,
-	  AdaptHeap<DLList, NullHeap<super> >,
-	  super> > >
+          Kingsley::size2Class,
+          Kingsley::class2Size,
+          AdaptHeap<DLList, NullHeap<super> >,
+          super> > >
 {};
 
 #else
 
 template <class super>
 class DLBigHeapType :
-  public 
+  public
 CoalesceHeap<RequireCoalesceable<
   SegHeap<DLBigHeapNS::NUMBINS,
-	  DLBigHeapNS::getSizeClass,
-	  DLBigHeapNS::getClassSize,
-	  AdaptHeap<DLList, NullHeap<super> >,
-	  super> > >
+          DLBigHeapNS::getSizeClass,
+          DLBigHeapNS::getClassSize,
+          AdaptHeap<DLList, NullHeap<super> >,
+          super> > >
 {};
 
 #endif
@@ -406,31 +407,31 @@ template <class super>
 class DLSmallHeapType :
   public RequireCoalesceable<
   StrictSegHeap<DLSmallHeapNS::NUMBINS,
-		DLSmallHeapNS::getSizeClass,
-		DLSmallHeapNS::getClassSize,
-		AdaptHeap<HL::SLList, NullHeap<super> >,
-		super> > {};
+                DLSmallHeapNS::getSizeClass,
+                DLSmallHeapNS::getClassSize,
+                AdaptHeap<HL::SLList, NullHeap<super> >,
+                super> > {};
 
 
 /**
  * @class LeaHeap
  * @brief This heap approximates the algorithms used by DLmalloc 2.7.0.
- * 
+ *
  * The whole thing. Big objects are allocated via mmap.
  * Other objects are first allocated from the special thresholded quicklists,
- * or if they're too big, they're allocated from the coalescing big heap. 
+ * or if they're too big, they're allocated from the coalescing big heap.
  *
  * @param Sbrk An sbrk-like heap, for small object allocation.
  * @param Mmap An mmap-like heap, for large object allocation.
  */
-  
+
 template <class Sbrk, class Mmap>
 class LeaHeap :
   public
     SelectMmapHeap<128 * 1024,
-		   Threshold<4096,
-			     DLSmallHeapType<DLBigHeapType<CoalesceableHeap<Sbrk> > > >,
-		   CoalesceableMmapHeap<Mmap> >
+                   Threshold<4096,
+                             DLSmallHeapType<DLBigHeapType<CoalesceableHeap<Sbrk> > > >,
+                   CoalesceableMmapHeap<Mmap> >
 {};
 
 }

--- a/heaps/general/kingsleyheap.h
+++ b/heaps/general/kingsleyheap.h
@@ -47,7 +47,7 @@ namespace Kingsley {
     size_t sz = (size_t) (1 << (i+3));
     return sz;
   }
-  
+
   static inline int ceilLog2 (size_t);
 
   inline int size2Class (const size_t sz) {
@@ -57,25 +57,25 @@ namespace Kingsley {
 
   /// Quickly calculate the CEILING of the log (base 2) of the argument.
 #if defined(_WIN32)
-  static inline int ceilLog2 (size_t sz) 
+  static inline int ceilLog2 (size_t sz)
   {
     int retval;
     sz = (sz << 1) - 1;
     __asm {
       bsr eax, sz
-	mov retval, eax
-	}
+        mov retval, eax
+        }
     return retval;
   }
 #elif defined(__GNUC__) && defined(__i386__)
-  static inline int ceilLog2 (size_t sz) 
+  static inline int ceilLog2 (size_t sz)
   {
     sz = (sz << 1) - 1;
     asm ("bsrl %0, %0" : "=r" (sz) : "0" (sz));
     return (int) sz;
   }
 #elif 0 // defined(__GNUC__) && defined(__x86_64__)
-  static inline int ceilLog2 (size_t sz) 
+  static inline int ceilLog2 (size_t sz)
   {
     sz = (sz << 1) - 1;
     asm ("bsrq %0, %0" : "=r" (sz) : "0" (sz));
@@ -83,7 +83,7 @@ namespace Kingsley {
   }
 #elif defined(__GNUC__)
   // Just use the intrinsic.
-  static inline int ceilLog2 (size_t sz) 
+  static inline int ceilLog2 (size_t sz)
   {
     sz = (sz << 1) - 1;
     return (sizeof(unsigned long) * 8) - __builtin_clzl(sz) - 1;
@@ -115,12 +115,12 @@ namespace Kingsley {
 namespace HL {
 
 template <class PerClassHeap, class BigHeap>
-  class KingsleyHeap : 
+  class KingsleyHeap :
    public StrictSegHeap<Kingsley::NUMBINS,
-			Kingsley::size2Class,
-			Kingsley::class2Size,
-			PerClassHeap,
-			BigHeap> {};
+                        Kingsley::size2Class,
+                        Kingsley::class2Size,
+                        PerClassHeap,
+                        BigHeap> {};
 
 }
 

--- a/heaps/general/oldkingsleyheap.h
+++ b/heaps/general/oldkingsleyheap.h
@@ -49,8 +49,8 @@ namespace Kingsley {
   inline int popc (int v) {
     int r;
     asm volatile ("popc %1, %0"
-		  : "=r" (r)
-		  : "r" (v));
+                  : "=r" (r)
+                  : "r" (v));
     return r;
   }
 #endif
@@ -84,8 +84,8 @@ namespace Kingsley {
       int c = 4;
       size_t sz1 = ((sz - 1) >> 4);
       while (sz1 > 7) {
-	sz1 >>= 1;
-	c++;
+        sz1 >>= 1;
+        c++;
       }
       assert (class2Size(c) >= sz);
       return c;
@@ -113,12 +113,12 @@ namespace Kingsley {
 namespace HL {
 
 template <class PerClassHeap, class BigHeap>
-  class KingsleyHeap : 
+  class KingsleyHeap :
    public StrictSegHeap<Kingsley::NUMBINS,
-			Kingsley::size2Class,
-			Kingsley::class2Size,
-			PerClassHeap,
-			BigHeap> {};
+                        Kingsley::size2Class,
+                        Kingsley::class2Size,
+                        PerClassHeap,
+                        BigHeap> {};
 
 }
 

--- a/heaps/objectrep/addheap.h
+++ b/heaps/objectrep/addheap.h
@@ -37,13 +37,13 @@ namespace HL {
   template <class Add, class SuperHeap>
   class AddHeap : public SuperHeap {
   public:
-  
+
     inline void * malloc (size_t sz) {
       void * ptr = SuperHeap::malloc (sz + HeaderSize);
       void * newPtr = (char *) ptr + HeaderSize;
       return newPtr;
     }
-  
+
     inline void free (void * ptr) {
       SuperHeap::free (getOriginal(ptr));
     }

--- a/heaps/objectrep/coalesceableheap.h
+++ b/heaps/objectrep/coalesceableheap.h
@@ -71,7 +71,7 @@ public:
 
   // The Header for every object, allocated or freed.
   class Header {
-	  friend class RequireCoalesceable<SuperHeap>;
+    friend class RequireCoalesceable<SuperHeap>;
   public:
 
     //
@@ -79,13 +79,13 @@ public:
     // Returns the start of the object (i.e., just past the header).
     //
     inline static void * makeObject (void * buf, const size_t prevsz, const size_t sz) {
-	  *((Header *) buf) = Header (prevsz, sz);
-	  Header * nextHeader = (Header *) ((char *) ((Header *) buf + 1) + sz);
-//	  Header * nextHeader = h->getNextHeader();
-//	  nextHeader->markPrevInUse();
-	  nextHeader->setPrevSize (sz);
+      *((Header *) buf) = Header (prevsz, sz);
+      Header * nextHeader = (Header *) ((char *) ((Header *) buf + 1) + sz);
+      // Header * nextHeader = h->getNextHeader();
+      // nextHeader->markPrevInUse();
+      nextHeader->setPrevSize (sz);
       // return Header::getObject (h);
-	  return ((Header *) buf + 1);
+      return ((Header *) buf + 1);
     }
 
 
@@ -98,7 +98,7 @@ public:
       assert (getNextHeader()->getPrev() == getObject(this));
 #if 0
       if (isPrevFree()) {
-	assert (getPrevSize() == getHeader(getPrev())->getSize());
+        assert (getPrevSize() == getHeader(getPrev())->getSize());
       }
 #endif
 #endif
@@ -116,33 +116,33 @@ public:
 //  private:
     inline size_t getPrevSize (void) const { return _prevSize; }
 
-    inline void markFree (void)        {
-		// printf ("markFree\n");
-		getNextHeader()->markPrevFree();
-	}
+    inline void markFree (void) {
+      // printf ("markFree\n");
+      getNextHeader()->markPrevFree();
+    }
     inline void markInUse (void)       {
-		// printf ("markInUse\n");
-		getNextHeader()->markPrevInUse();
-	}
+      // printf ("markInUse\n");
+      getNextHeader()->markPrevInUse();
+    }
     inline void markMmapped (void)     { _isMmapped = IS_MMAPPED; }
     inline void markNotMmapped (void)  { _isMmapped = NOT_MMAPPED; }
     inline int isFree (void) const     {
-		// printf ("isFree\n");
-		return getNextHeader()->isPrevFree();
-	}
+      // printf ("isFree\n");
+      return getNextHeader()->isPrevFree();
+    }
     inline int isNextFree (void) const {
-		// printf ("isNextFree\n");
-		return getNextHeader()->getNextHeader()->isPrevFree();
-	}
+      // printf ("isNextFree\n");
+      return getNextHeader()->getNextHeader()->isPrevFree();
+    }
     inline int isMmapped (void) const  { return (_isMmapped != NOT_MMAPPED); }
     inline void * getPrev (void) const {
-	//	fprintf (stderr, "coalesceableheap.h: %x, %d\n", this, getPrevSize());
-		return ((char *) this) - getPrevSize(); 
-	}
-    inline void * getNext (void) const { 
-		// printf ("getNext\n");
-		return ((char *) (this + 2)) + getSize();
-	}
+      // fprintf (stderr, "coalesceableheap.h: %x, %d\n", this, getPrevSize());
+      return ((char *) this) - getPrevSize();
+    }
+    inline void * getNext (void) const {
+      // printf ("getNext\n");
+      return ((char *) (this + 2)) + getSize();
+    }
 
     inline void markPrevFree (void)    { _prevStatus = PREV_FREE; }
     inline void markPrevInUse (void)   { _prevStatus = PREV_INUSE; }
@@ -279,7 +279,7 @@ public:
       header->setSize (sz);
 
       // Below was:
-//      Header * nextHeader = Header::getHeader (header->getNext());
+      // Header * nextHeader = Header::getHeader (header->getNext());
       Header * nextHeader = (Header *) ((char *) (header + 1) + sz);
 
       nextHeader->setPrevSize (sz);
@@ -314,7 +314,7 @@ public:
       // accidental coalescing.
       //
 
-//	  (nextHeader + 1)->markPrevInUse();
+      // (nextHeader + 1)->markPrevInUse();
       nextHeader->markInUse ();
 #endif
 
@@ -324,7 +324,7 @@ public:
     }
     return NULL;
   }
-  
+
   inline void free (void * ptr) {
     assert (SuperHeap::isFree(ptr));
     SuperHeap::free ((Header *) ptr - 1);

--- a/heaps/objectrep/sizeheap.h
+++ b/heaps/objectrep/sizeheap.h
@@ -39,60 +39,60 @@
 #include "utility/gcd.h"
 
 namespace HL {
-  
+
   /**
    * @class SizeHeap
    * @brief Allocates extra room for the size of an object.
    */
-  
+
   template <class SuperHeap>
   class SizeHeap : public SuperHeap {
-    
+
   private:
     struct freeObject {
       size_t _sz;
       size_t _magic;
       //      char _buf[HL::MallocInfo::Alignment];
     };
-    
+
   public:
-    
+
     enum { Alignment = gcd<(int) SuperHeap::Alignment,
 	   (int) sizeof(freeObject)>::value };
-  
+
     virtual ~SizeHeap (void) {}
-    
+
     inline void * malloc (size_t sz) {
       freeObject * p = (freeObject *) SuperHeap::malloc (sz + sizeof(freeObject));
       p->_sz = sz;
       p->_magic = 0xcafebabe;
       return (void *) (p + 1);
     }
-    
+
     inline void free (void * ptr) {
       assert (getHeader(ptr)->_magic == 0xcafebabe);
       SuperHeap::free (getHeader(ptr));
     }
-    
+
     inline static size_t getSize (const void * ptr) {
       assert (getHeader(ptr)->_magic == 0xcafebabe);
       size_t size = getHeader(ptr)->_sz;
       return size;
     }
-    
+
   private:
-    
+
     inline static void setSize (void * ptr, size_t sz) {
       assert (getHeader(ptr)->_magic == 0xcafebabe);
       getHeader(ptr)->_sz = sz;
     }
-    
+
     inline static freeObject * getHeader (const void * ptr) {
       return ((freeObject *) ptr - 1);
     }
-    
+
   };
-  
+
 }
 
 #endif

--- a/heaps/objectrep/sizeownerheap.h
+++ b/heaps/objectrep/sizeownerheap.h
@@ -57,7 +57,7 @@ private:
   typedef AddHeap<SizeOwner<Super>, Super> SuperHeap;
 
 public:
-  
+
   inline void * malloc (size_t sz) {
     void * ptr = SuperHeap::malloc (sz);
     // Store the requested size.
@@ -67,7 +67,7 @@ public:
     // Store the owner.
     return (void *) (so + 1);
   }
-  
+
   inline void free (void * ptr) {
     void * origPtr = (void *) ((SizeOwner<Super> *) ptr - 1);
     SuperHeap::free (origPtr);

--- a/heaps/special/bumpalloc.h
+++ b/heaps/special/bumpalloc.h
@@ -27,7 +27,10 @@
 #ifndef HL_BUMPALLOC_H
 #define HL_BUMPALLOC_H
 
+#include <cstddef>
+
 #include "utility/gcd.h"
+#include "utility/sassert.h"
 
 /**
  * @class BumpAlloc
@@ -49,12 +52,12 @@ namespace HL {
       : _bump (NULL),
 	_remaining (0)
     {
-      sassert<(gcd<ChunkSize, Alignment>::VALUE == Alignment)> 
-	verifyAlignmentSatisfiable;
+      sassert<(gcd<ChunkSize, Alignment>::VALUE == Alignment)>
+      verifyAlignmentSatisfiable;
       sassert<(gcd<SuperHeap::Alignment, Alignment>::VALUE == Alignment)>
-	verifyAlignmentFromSuperHeap;
+      verifyAlignmentFromSuperHeap;
       sassert<((Alignment & (Alignment-1)) == 0)>
-	verifyPowerOfTwoAlignment;
+      verifyPowerOfTwoAlignment;
     }
 
     inline void * malloc (size_t sz) {
@@ -64,7 +67,7 @@ namespace HL {
       // If there's not enough space left to fulfill this request, get
       // another chunk.
       if (_remaining < newSize) {
-	refill(newSize);
+        refill(newSize);
       }
       // Bump that pointer.
       char * old = _bump;
@@ -89,7 +92,7 @@ namespace HL {
     // Get another chunk.
     void refill (size_t sz) {
       if (sz < ChunkSize) {
-	sz = ChunkSize;
+        sz = ChunkSize;
       }
       _bump = (char *) SuperHeap::malloc (sz);
       assert ((size_t) _bump % Alignment == 0);

--- a/heaps/special/nestedheap.h
+++ b/heaps/special/nestedheap.h
@@ -71,15 +71,15 @@ public:
     if (child != NULL) {
       NestedHeap<SuperHeap> * nextChild = child->next;
       while (child != NULL) {
-	NestedHeap<SuperHeap> * prevChild = child->prev;
-	delete child;
-	child = prevChild;
+        NestedHeap<SuperHeap> * prevChild = child->prev;
+        delete child;
+        child = prevChild;
       }
       child = nextChild;
       while (child != NULL) {
-	nextChild = child->next;
-	delete child;
-	child = nextChild;
+        nextChild = child->next;
+        delete child;
+        child = nextChild;
       }
     }
     assert (child == NULL);
@@ -120,11 +120,11 @@ private:
     assert (ch != NULL);
     if (child == ch) {
       if (ch->prev) {
-	child = ch->prev;
+        child = ch->prev;
       } else if (ch->next) {
-	child = ch->next;
+        child = ch->next;
       } else {
-	child = NULL;
+        child = NULL;
       }
     }
     removeSibling (ch);

--- a/heaps/special/obstack.h
+++ b/heaps/special/obstack.h
@@ -61,10 +61,10 @@ namespace HL {
       assert (isValid());
       ChunkHeader * ch = currentChunk;
       while (ch != NULL) {
-	ChunkHeader * pch = ch->getPrevChunk();
-	// cout << "Freeing chunk " << ch << endl;
-	SuperHeap::free (ch);
-	ch = pch;
+        ChunkHeader * pch = ch->getPrevChunk();
+        // cout << "Freeing chunk " << ch << endl;
+        SuperHeap::free (ch);
+        ch = pch;
       }
     }
 
@@ -75,16 +75,16 @@ namespace HL {
       // get a new one.
       assert (isValid());
       if ((int) ((char *) currentChunk->getLimit() - (char *) nextPos) < sz) {
-	ChunkHeader * newCurrent = copyToNew(sz);
-	if (newCurrent == NULL)
-	  return NULL;
+        ChunkHeader * newCurrent = copyToNew(sz);
+        if (newCurrent == NULL)
+          return NULL;
 #if 0
-	// Now delete the previous chunk if this was the only object in it.
-	if (deleteChunk != NULL) {
-	  SuperHeap::free (deleteChunk);
-	}
+        // Now delete the previous chunk if this was the only object in it.
+        if (deleteChunk != NULL) {
+          SuperHeap::free (deleteChunk);
+        }
 #endif
-	assert (isValid());
+        assert (isValid());
       }
       assert (((int) ((char *) currentChunk->getLimit() - (char *) nextPos) >= sz));
       assert ((char *) (sz + nextPos) <= currentChunk->getLimit());
@@ -99,19 +99,19 @@ namespace HL {
     inline void * malloc (size_t sz) {
       assert (isValid());
       if (currentChunk == NULL) {
-	return NULL;
+        return NULL;
       }
       //sz = align(sz > 0 ? sz : 1);
       // If this object can't fit in the current chunk,
       // get another one.
       if ((int) ((char *) currentChunk->getLimit() - (char *) nextPos) < sz) {
-	// Allocate a chunk that's large enough to hold the requested size.
-	currentChunk = makeChunk (currentChunk, sz);
-	if (currentChunk == NULL) {
-	  return NULL;
-	}
-	currentBase = nextPos = (char *) (currentChunk + 1);
-	assert (isValid());
+        // Allocate a chunk that's large enough to hold the requested size.
+        currentChunk = makeChunk (currentChunk, sz);
+        if (currentChunk == NULL) {
+          return NULL;
+        }
+        currentBase = nextPos = (char *) (currentChunk + 1);
+        assert (isValid());
       }
       assert (((int) ((char *) currentChunk->getLimit() - (char *) nextPos) >= sz));
       assert ((char *) (sz + nextPos) <= currentChunk->getLimit());
@@ -133,24 +133,24 @@ namespace HL {
       while (currentChunk != NULL &&
 	     (((char *) currentChunk > (char *) ptr) ||
 	      ((char *) currentChunk->getLimit() < (char *) ptr))) {
-	ChunkHeader * pch = currentChunk;
-	currentChunk = currentChunk->getPrevChunk();
-	SuperHeap::free (pch);
+        ChunkHeader * pch = currentChunk;
+        currentChunk = currentChunk->getPrevChunk();
+        SuperHeap::free (pch);
       }
       if (currentChunk != NULL) {
-	currentBase = nextPos = (char *) ptr;
-	assert (isValid());
+        currentBase = nextPos = (char *) ptr;
+        assert (isValid());
       } else {
-	if (ptr != NULL) {
-	  // Something bad has happened -- we tried to free an item that
-	  // wasn't in any chunk.
-	  abort();
-	} else {
-	  // Get one chunk.
-	  currentChunk = makeChunk (NULL, ChunkSize);
-	  currentBase = nextPos = (char *) (currentChunk + 1);
-	  assert (isValid());
-	}
+        if (ptr != NULL) {
+          // Something bad has happened -- we tried to free an item that
+          // wasn't in any chunk.
+          abort();
+        } else {
+          // Get one chunk.
+          currentChunk = makeChunk (NULL, ChunkSize);
+          currentBase = nextPos = (char *) (currentChunk + 1);
+          assert (isValid());
+        }
       }
     }
 
@@ -204,8 +204,8 @@ namespace HL {
     class ChunkHeader {
     public:
       inline ChunkHeader (ChunkHeader * prev, size_t sz)
-	: _pastEnd ((char *) (this + 1) + sz),
-	  _prevChunk (prev)
+        : _pastEnd ((char *) (this + 1) + sz),
+        _prevChunk (prev)
       {}
 
       // Return the end of the current chunk.
@@ -227,10 +227,10 @@ namespace HL {
     inline ChunkHeader * makeChunk (ChunkHeader * ch, size_t sz) {
       // Round up the allocation size to at least one chunk.
       size_t allocSize
-	= HL::align<sizeof(double)>((sz > ChunkSize - sizeof(ChunkHeader)) ? sz : ChunkSize - sizeof(ChunkHeader));
+        = HL::align<sizeof(double)>((sz > ChunkSize - sizeof(ChunkHeader)) ? sz : ChunkSize - sizeof(ChunkHeader));
       // Make a new chunk.
-      ChunkHeader * newChunk 
-	= new (SuperHeap::malloc (sizeof(ChunkHeader) + allocSize)) ChunkHeader (ch, allocSize);
+      ChunkHeader * newChunk
+        = new (SuperHeap::malloc (sizeof(ChunkHeader) + allocSize)) ChunkHeader (ch, allocSize);
       return newChunk;
     }
 
@@ -257,8 +257,8 @@ namespace HL {
       newChunk = makeChunk (currentChunk, new_size);
 #endif
       if (newChunk == NULL) {
-	currentChunk = NULL;
-	return NULL;
+        currentChunk = NULL;
+        return NULL;
       }
       // Copy the current object to the new chunk.
       memcpy ((char *) (newChunk + 1), currentBase, obj_size);

--- a/heaps/special/obstackheap.h
+++ b/heaps/special/obstackheap.h
@@ -55,10 +55,10 @@ namespace HL {
       assert (isValid());
       ChunkHeader * ch = currentChunk;
       while (ch != NULL) {
-	ChunkHeader * pch = ch->getPrevChunk();
-	// cout << "Freeing chunk " << ch << endl;
-	SuperHeap::free (ch);
-	ch = pch;
+        ChunkHeader * pch = ch->getPrevChunk();
+        // cout << "Freeing chunk " << ch << endl;
+        SuperHeap::free (ch);
+        ch = pch;
       }
     }
 
@@ -69,16 +69,16 @@ namespace HL {
       // get a new one.
       assert (isValid());
       if ((int) ((char *) currentChunk->getLimit() - (char *) nextPos) < sz) {
-	ChunkHeader * newCurrent = copyToNew(sz);
-	if (newCurrent == NULL)
-	  return NULL;
+        ChunkHeader * newCurrent = copyToNew(sz);
+        if (newCurrent == NULL)
+          return NULL;
 #if 0
-	// Now delete the previous chunk if this was the only object in it.
-	if (deleteChunk != NULL) {
-	  SuperHeap::free (deleteChunk);
-	}
+        // Now delete the previous chunk if this was the only object in it.
+        if (deleteChunk != NULL) {
+          SuperHeap::free (deleteChunk);
+        }
 #endif
-	assert (isValid());
+        assert (isValid());
       }
       assert (((int) ((char *) currentChunk->getLimit() - (char *) nextPos) >= sz));
       assert ((char *) (sz + nextPos) <= currentChunk->getLimit());
@@ -93,19 +93,19 @@ namespace HL {
     inline void * malloc (size_t sz) {
       assert (isValid());
       if (currentChunk == NULL) {
-	return NULL;
+        return NULL;
       }
       //sz = align(sz > 0 ? sz : 1);
       // If this object can't fit in the current chunk,
       // get another one.
       if ((int) ((char *) currentChunk->getLimit() - (char *) nextPos) < sz) {
-	// Allocate a chunk that's large enough to hold the requested size.
-	currentChunk = makeChunk (currentChunk, sz);
-	if (currentChunk == NULL) {
-	  return NULL;
-	}
-	currentBase = nextPos = (char *) (currentChunk + 1);
-	assert (isValid());
+        // Allocate a chunk that's large enough to hold the requested size.
+        currentChunk = makeChunk (currentChunk, sz);
+        if (currentChunk == NULL) {
+          return NULL;
+        }
+        currentBase = nextPos = (char *) (currentChunk + 1);
+        assert (isValid());
       }
       assert (((int) ((char *) currentChunk->getLimit() - (char *) nextPos) >= sz));
       assert ((char *) (sz + nextPos) <= currentChunk->getLimit());
@@ -127,24 +127,24 @@ namespace HL {
       while (currentChunk != NULL &&
 	     (((char *) currentChunk > (char *) ptr) ||
 	      ((char *) currentChunk->getLimit() < (char *) ptr))) {
-	ChunkHeader * pch = currentChunk;
-	currentChunk = currentChunk->getPrevChunk();
-	SuperHeap::free (pch);
+        ChunkHeader * pch = currentChunk;
+        currentChunk = currentChunk->getPrevChunk();
+        SuperHeap::free (pch);
       }
       if (currentChunk != NULL) {
-	currentBase = nextPos = (char *) ptr;
-	assert (isValid());
+        currentBase = nextPos = (char *) ptr;
+        assert (isValid());
       } else {
-	if (ptr != NULL) {
-	  // Something bad has happened -- we tried to free an item that
-	  // wasn't in any chunk.
-	  abort();
-	} else {
-	  // Get one chunk.
-	  currentChunk = makeChunk (NULL, ChunkSize);
-	  currentBase = nextPos = (char *) (currentChunk + 1);
-	  assert (isValid());
-	}
+        if (ptr != NULL) {
+          // Something bad has happened -- we tried to free an item that
+          // wasn't in any chunk.
+          abort();
+        } else {
+          // Get one chunk.
+          currentChunk = makeChunk (NULL, ChunkSize);
+          currentBase = nextPos = (char *) (currentChunk + 1);
+          assert (isValid());
+        }
       }
     }
 
@@ -198,8 +198,8 @@ namespace HL {
     class ChunkHeader {
     public:
       inline ChunkHeader (ChunkHeader * prev, size_t sz)
-	: _pastEnd ((char *) (this + 1) + sz),
-	  _prevChunk (prev)
+        : _pastEnd ((char *) (this + 1) + sz),
+        _prevChunk (prev)
       {}
 
       // Return the end of the current chunk.
@@ -220,14 +220,14 @@ namespace HL {
     inline ChunkHeader * makeChunk (ChunkHeader * ch, size_t sz) {
       // Round up the allocation size to at least one chunk.
       size_t allocSize
-	= HL::align<Alignment>((sz > ChunkSize - sizeof(ChunkHeader)) ? sz : ChunkSize - sizeof(ChunkHeader));
+        = HL::align<Alignment>((sz > ChunkSize - sizeof(ChunkHeader)) ? sz : ChunkSize - sizeof(ChunkHeader));
       // Make a new chunk.
       void * ptr = SuperHeap::malloc (sizeof(ChunkHeader) + allocSize);
       if (ptr == NULL) {
-	return NULL;
+        return NULL;
       }
-      ChunkHeader * newChunk 
-	= new (ptr) ChunkHeader (ch, allocSize);
+      ChunkHeader * newChunk
+        = new (ptr) ChunkHeader (ch, allocSize);
       return newChunk;
     }
 
@@ -245,17 +245,17 @@ namespace HL {
       // If this object was the only one in the chunk,
       // link back past this chunk.
       if (currentBase == (char *) (currentChunk + 1)) {
-	newChunk = makeChunk (currentChunk->getPrevChunk(), new_size);
-	deleteChunk = currentChunk;
+        newChunk = makeChunk (currentChunk->getPrevChunk(), new_size);
+        deleteChunk = currentChunk;
       } else {
-	newChunk = makeChunk (currentChunk, new_size);
+        newChunk = makeChunk (currentChunk, new_size);
       }
 #else
       newChunk = makeChunk (currentChunk, new_size);
 #endif
       if (newChunk == NULL) {
-	currentChunk = NULL;
-	return NULL;
+        currentChunk = NULL;
+        return NULL;
       }
       // Copy the current object to the new chunk.
       memcpy ((char *) (newChunk + 1), currentBase, obj_size);
@@ -264,7 +264,7 @@ namespace HL {
       nextPos = currentBase + obj_size;
 #if 0
       if (deleteChunk != NULL) {
-	SuperHeap::free (deleteChunk);
+        SuperHeap::free (deleteChunk);
       }
 #endif
       return currentChunk;

--- a/heaps/special/obstackreap.h
+++ b/heaps/special/obstackreap.h
@@ -4,12 +4,13 @@
 #define HL_OBSTACKREAP_H
 
 #include <assert.h>
+#include <iostream>
 
 /*
 
   ObstackReap layers obstack functionality on top of reaps.
 
-  */
+ */
 
 #if WIN32
 #include <windows.h>
@@ -27,20 +28,20 @@ namespace ObstackReapNS {
       : internalArray (0),
 	internalArrayLength (0)
     {}
-    
+
     ~DynamicArray (void)
     {
       clear();
     }
-    
+
     // clear deletes everything in the array.
 
     inline void clear (void) {
       if (internalArray) {
-	delete [] internalArray;
-	internalArray = 0;
-	internalArrayLength = 0;
-	//printf ("\ninternalArrayLength %x = %d\n", this, internalArrayLength);
+        delete [] internalArray;
+        internalArray = 0;
+        internalArrayLength = 0;
+        //printf ("\ninternalArrayLength %x = %d\n", this, internalArrayLength);
       }
     }
 
@@ -60,25 +61,25 @@ namespace ObstackReapNS {
       assert (index >= 0);
       if (index >= internalArrayLength) {
 
-	// This index is beyond the current size of the array.
-	// Grow the array by doubling and copying the old array into the new.
+        // This index is beyond the current size of the array.
+        // Grow the array by doubling and copying the old array into the new.
 
-	const int newSize = index * 2 + 1;
-	ObjType * arr = new ObjType[newSize];
-	// printf ("grow! %d to %d\n", internalArrayLength, newSize);
+        const int newSize = index * 2 + 1;
+        ObjType * arr = new ObjType[newSize];
+        // printf ("grow! %d to %d\n", internalArrayLength, newSize);
 #if MALLOC_TRACE
-	printf ("m %x %d\n", arr, newSize * sizeof(ObjType));
+        printf ("m %x %d\n", arr, newSize * sizeof(ObjType));
 #endif
-	if (internalArray) {
-	  memcpy (arr, internalArray, internalArrayLength * sizeof(ObjType));
-	  delete [] internalArray;
+        if (internalArray) {
+          memcpy (arr, internalArray, internalArrayLength * sizeof(ObjType));
+          delete [] internalArray;
 #if MALLOC_TRACE
-	  printf ("f %x\n", internalArray);
+          printf ("f %x\n", internalArray);
 #endif
-	}
-	internalArray = arr;
-	internalArrayLength = newSize;
-	// printf ("\ninternalArrayLength %x = %d\n", this, internalArrayLength);
+        }
+        internalArray = arr;
+        internalArrayLength = newSize;
+        // printf ("\ninternalArrayLength %x = %d\n", this, internalArrayLength);
       }
       return internalArray[index];
     }
@@ -93,22 +94,22 @@ namespace ObstackReapNS {
       // drops below one-fourth of the array size.
 
       if (internalArray) {
-	if (nelts * 4 < internalArrayLength) {
-	  const int newSize = nelts * 2;
-	  ObjType * arr = new ObjType[newSize];
-	  // printf ("trim! %d to %d\n", internalArrayLength, newSize);
+        if (nelts * 4 < internalArrayLength) {
+          const int newSize = nelts * 2;
+          ObjType * arr = new ObjType[newSize];
+          // printf ("trim! %d to %d\n", internalArrayLength, newSize);
 #if MALLOC_TRACE
-	  printf ("m %x %d\n", arr, newSize * sizeof(ObjType));
+          printf ("m %x %d\n", arr, newSize * sizeof(ObjType));
 #endif
-	  memcpy (arr, internalArray, sizeof(ObjType) * nelts);
-	  delete [] internalArray;
+          memcpy (arr, internalArray, sizeof(ObjType) * nelts);
+          delete [] internalArray;
 #if MALLOC_TRACE
-	  printf ("f %x\n", internalArray);
+          printf ("f %x\n", internalArray);
 #endif
-	  internalArray = arr;
-	  internalArrayLength = newSize;
-	}
-	assert (nelts <= internalArrayLength);
+          internalArray = arr;
+          internalArrayLength = newSize;
+        }
+        assert (nelts <= internalArrayLength);
       }
     }
 
@@ -120,7 +121,7 @@ namespace ObstackReapNS {
     ObjType * internalArray;
 
     // The length of the internal array, in elements.
-	
+
     int internalArrayLength;
   };
 #endif
@@ -144,10 +145,10 @@ namespace ObstackReapNS {
     inline OBJTYPE * pop (void) {
       OBJTYPE * ptr = 0;
       if (numItems > 0) {
-	ptr = items[numItems];
-	numItems--;
-	// The array has shrunk, so potentially trim it.
-	items.trim (numItems + 1);
+        ptr = items[numItems];
+        numItems--;
+        // The array has shrunk, so potentially trim it.
+        items.trim (numItems + 1);
       }
       return ptr;
     }
@@ -155,7 +156,7 @@ namespace ObstackReapNS {
     inline OBJTYPE * top (void) {
       OBJTYPE * ptr = NULL;
       if (numItems > 0) {
-	ptr = items[numItems];
+        ptr = items[numItems];
       }
       return ptr;
     }
@@ -163,9 +164,9 @@ namespace ObstackReapNS {
     inline void clear (void) {
       items.clear();
     }
-  
+
   private:
-  
+
     // The number of items recorded above.
     // 0 == no items.
     // 1 == items[1] has the single item, etc.
@@ -175,7 +176,7 @@ namespace ObstackReapNS {
 
     // The array of remembered objects.
 
-    DynamicArray<OBJTYPE *> items;
+    HL::DynamicArray<OBJTYPE *> items;
   };
 
 };
@@ -201,7 +202,7 @@ public:
     delete currentReap;
     delete currentObject;
   }
-  
+
   inline void * malloc (size_t sz);
   inline void freeAfter (void * ptr);
   inline void freeAll (void);
@@ -264,7 +265,7 @@ void ObstackReap<ReapType>::freeAll (void) {
     delete currentReap;
     currentReap = reapStack.pop();
   }
-  currentHeap = new ReapType;
+  currentReap = new ReapType;
 }
 
 
@@ -289,7 +290,7 @@ inline void * ObstackReap<ReapType>::grow (size_t sz) {
   const int requestedObjectSize = currentObjectSize + sz;
 
   if (requestedObjectSize > actualObjectSize) {
-    cout << "resize!\n";
+    std::cout << "resize!\n";
     void * ptr = currentReap->realloc (currentObject, sz);
     currentObjectPosition = (char *) ptr + (currentObjectPosition - (char *) currentObject);
     if (isCurrentObjectExposed) {

--- a/heaps/special/sbrk.c
+++ b/heaps/special/sbrk.c
@@ -21,7 +21,7 @@ void * sbrk (long size) {
   static long remainingCommitted = 0;
   static long pageSize;
   void * p;
-  
+
   if (!initialized) {
 
     /*
@@ -35,16 +35,16 @@ void * sbrk (long size) {
     SYSTEM_INFO sSysInfo;
     LPVOID base;
     GetSystemInfo(&sSysInfo);
-    
+
     pageSize = sSysInfo.dwPageSize;
-    
+
     /* Reserve pages in the process's virtual address space. */
-    
+
 #if 1
     base = VirtualAlloc(NULL, remainingReserved, MEM_RESERVE, PAGE_NOACCESS);
 #else
     base = VirtualAlloc(NULL, remainingReserved, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
-	remainingCommitted =  PRE_RESERVE;
+    remainingCommitted =  PRE_RESERVE;
 #endif
 
     if (base == NULL )
@@ -58,16 +58,16 @@ void * sbrk (long size) {
 
 #if 0
   /* Uncommit pages if possible.
-       Round the size down to a multiple of the page size,
-       and decommit those pages.
-    */
+     Round the size down to a multiple of the page size,
+     and decommit those pages.
+   */
 
 
     int bytesToUncommit = (-size & ~(pageSize - 1));
 
     if (bytesToUncommit > PRE_RESERVE - remainingReserved) {
       /* Error -- the user has tried to free memory that we never
-	 even reserved. */
+         even reserved. */
       return currentPosition;
     }
 
@@ -75,8 +75,8 @@ void * sbrk (long size) {
 
       int result = VirtualFree (nextPage - bytesToUncommit, bytesToUncommit, MEM_DECOMMIT);
       if (result == 0) {
-	/* Error -- don't change a thing. */
-	return currentPosition;
+        /* Error -- don't change a thing. */
+        return currentPosition;
       }
       remainingCommitted -= bytesToUncommit;
     }
@@ -93,8 +93,8 @@ void * sbrk (long size) {
     if (size > remainingCommitted) {
 
       /* Commit some more pages.
-	 We round up to an even number of pages.
-	 Note that page size must be a power of two.
+         We round up to an even number of pages.
+         Note that page size must be a power of two.
       */
 
       int bytesToCommit = (size - remainingCommitted + pageSize - 1) & ~(pageSize - 1); 
@@ -103,12 +103,12 @@ void * sbrk (long size) {
       result = VirtualAlloc((LPVOID) nextPage, bytesToCommit, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 
       if (result == NULL )
-	exit (1); /* VirtualAlloc commit failed */
+        exit (1); /* VirtualAlloc commit failed */
 
       nextPage += bytesToCommit;
       remainingCommitted += bytesToCommit;
     }
-      
+
     p = currentPosition;
     currentPosition += size;
     remainingCommitted -= size;

--- a/heaps/special/xallocheap.h
+++ b/heaps/special/xallocheap.h
@@ -27,6 +27,9 @@
 #ifndef HL_XALLOCHEAP_H
 #define HL_XALLOCHEAP_H
 
+#include <cstddef>
+#include <utility/align.h>
+
 namespace HL {
 
   template <int ArenaSize, class SuperHeap>
@@ -49,8 +52,8 @@ namespace HL {
       char * old_end_of_array = end_of_array;
       end_of_array += HL::align<sizeof(double)>(size + sizeof(Nuggie));
       if (old_end_of_array + size >= start_of_array + ArenaSize) {
-	// We're out of memory.
-	return NULL;
+        // We're out of memory.
+        return NULL;
       }
       size_lval(end_of_array) = end_of_array - old_end_of_array;
       clear_use(end_of_array);  /* this is not necessary, cause it will be zero */
@@ -66,20 +69,20 @@ namespace HL {
 	 is set, and also check that the size is right */
       clear_use(p);  /* mark this block as unused */
       if (p == last_block) {
-	while (1) {
-	  q = prev_block(p);
-	  if (q == p) {
-	    last_block = NULL;
-	    end_of_array = p;
-	    break;  /* only happens when we get to the beginning */
-	  }
-	  if (in_use(q)) {
-	    last_block = q;
-	    end_of_array = p;
-	    break;
-	  }
-	  p = q;
-	}
+        while (1) {
+          q = prev_block(p);
+          if (q == p) {
+            last_block = NULL;
+            end_of_array = p;
+            break;  /* only happens when we get to the beginning */
+          }
+          if (in_use(q)) {
+            last_block = q;
+            end_of_array = p;
+            break;
+          }
+          p = q;
+        }
       }
     }
 

--- a/heaps/threads/lockedheap.h
+++ b/heaps/threads/lockedheap.h
@@ -27,6 +27,7 @@
 #ifndef HL_LOCKEDHEAP_H
 #define HL_LOCKEDHEAP_H
 
+#include <cstddef>
 #include "utility/guard.h"
 
 namespace HL {
@@ -41,7 +42,7 @@ namespace HL {
       Guard<LockType> l (thelock);
       return Super::malloc (sz);
     }
-  
+
     inline void free (void * ptr) {
       Guard<LockType> l (thelock);
       Super::free (ptr);
@@ -62,9 +63,9 @@ namespace HL {
     }
 
     inline void unlock (void) {
-      thelock.unlock(); 
+      thelock.unlock();
     }
- 
+
   private:
     //    char dummy[128]; // an effort to avoid false sharing.
     LockType thelock;

--- a/heaps/top/sbrkheap.h
+++ b/heaps/top/sbrkheap.h
@@ -3,6 +3,8 @@
 #ifndef HL_SBRKHEAP_H
 #define HL_SBRKHEAP_H
 
+#include <cstddef>
+
 #ifdef WIN32
 
 // If we're using Windows, we'll need to link in sbrk.c,

--- a/heaps/top/staticheap.h
+++ b/heaps/top/staticheap.h
@@ -33,6 +33,8 @@
 #ifndef HL_STATICHEAP_H
 #define HL_STATICHEAP_H
 
+#include <cstddef>
+
 namespace HL {
 
   template <int MemorySize>

--- a/heaps/utility/localmallocheap.h
+++ b/heaps/utility/localmallocheap.h
@@ -27,6 +27,10 @@
 #ifndef HL_LOCALMALLOCHEAP_H
 #define HL_LOCALMALLOCHEAP_H
 
+#include <cstddef>
+#include <cassert>
+#include <iostream>
+
 #if !defined(_WIN32) // not implemented for Windows
 
 #include <dlfcn.h>

--- a/heaps/utility/slopheap.h
+++ b/heaps/utility/slopheap.h
@@ -27,6 +27,8 @@
 #ifndef HL_SLOPHEAP_H
 #define HL_SLOPHEAP_H
 
+#include <cstddef>
+
 /**
  * @class SlopHeap
  * 

--- a/locks/recursivelock.h
+++ b/locks/recursivelock.h
@@ -27,6 +27,7 @@
 #ifndef HL_RECURSIVELOCK_H
 #define HL_RECURSIVELOCK_H
 
+#include <cassert>
 #include "threads/cpuinfo.h"
 
 /**

--- a/utility/bins4k.h
+++ b/utility/bins4k.h
@@ -3,6 +3,8 @@
 #if !defined(_BINS4K_H_)
 #define _BINS4K_H_
 
+#include <cassert>
+
 #include "bins.h"
 #include "sassert.h"
 

--- a/utility/bins8k.h
+++ b/utility/bins8k.h
@@ -3,6 +3,8 @@
 #if !defined(HL_BINS8K_H)
 #define HL_BINS8K_H
 
+#include <cassert>
+
 #include "bins.h"
 #include "sassert.h"
 


### PR DESCRIPTION
I fixed a number of errors in the header files that are present when the headers are used individually. Most problems involved not having a C header that defines `NULL` or `size_t`, which I fixed with `#include <cstddef>`.

I also fixed the formatting on about half of the heaps. It looks like there were 8 space tabs mixed with two spaces for tabbing. I also removed any extraneous whitespace that my editor identified.

The rest of the files have the same tabbing problem, but I did not have the patience to fix them. Theoretically, doing a global search/replace of `\t` with 8 spaces would fix everything, but a few had other spacing problems that had to be manually adjusted.
