### PR TITLE
Simple Initialization Order Change

### DIFF
--- a/heaps/utility/localmallocheap.h
+++ b/heaps/utility/localmallocheap.h
@@ -63,8 +63,8 @@ namespace HL {
       : freefn (NULL),
 	msizefn (NULL),
 	mallocfn (NULL),
-	_initializing (false),
-	_initialized (false)
+	_initialized (false),
+  _initializing (false)
     {}
 
     inline void * malloc (size_t sz) {


### PR DESCRIPTION
I turned on Clang warnings with `-Wall` and found that I missed this.

There are two other small issues that I was not bold enough to change:

```
heaps/threads/phothreadheap.h:36,11 - Warning - explicitly assigning a variable of type 'int' to itself [Disable with -Wno-self-assign]
heaps/threads/threadspecificheap.h:77,18 - Warning - unused variable 'r' [Disable with -Wno-unused-variable]
```
