### PR TITLE
Bug fix to support OSX 10.9.4

### DIFF
--- a/wrappers/macwrapper.cpp
+++ b/wrappers/macwrapper.cpp
@@ -491,6 +491,15 @@ public:
     theDefaultZone.free_definite_size = MACWRAPPER_PREFIX(malloc_zone_free_definite_size);
     theDefaultZone.pressure_relief = NULL;
     malloc_zone_register (&theDefaultZone);
+    // Unregister and reregister the default zone.  Unregistering swaps
+    // the specified zone with the last one registered which for the
+    // default zone makes the more recently registered zone the default
+    // zone.  The default zone is then re-registered to ensure that
+    // allocations made from it earlier will be handled correctly.
+    // Things are not guaranteed to work that way, but it's how they work now.
+    malloc_zone_t *default_zone = malloc_default_zone();
+    malloc_zone_unregister(default_zone);
+    malloc_zone_register(default_zone);
   }
 };
 


### PR DESCRIPTION
Honestly, this seems like a glorious hack, but it is something that the
google-perftools does (see
http://google-perftools.googlecode.com/svn/tags/google-perftools-1.8/src/libc_override_osx.h)
and, for me on OSX 10.9.4, is the only way to make the Heap-Layer
wrapper work.

Would appreciate to know if anyone can reproduce.
