### PR TITLE
STLAllocator wrapper API updates for C++11

### DIFF
--- a/wrappers/stlallocator.h
+++ b/wrappers/stlallocator.h
@@ -158,10 +158,6 @@ public:
   
 #endif
 
-  void destroy (pointer p) {
-    p->~T();
-  }
-
   template <class U> STLAllocator (const STLAllocator<U, Super> &) throw() 
   {
   }


### PR DESCRIPTION
The old API doesn't work with move constructors. See updated signatures for [construct](http://en.cppreference.com/w/cpp/memory/allocator/construct) and [destroy](http://en.cppreference.com/w/cpp/memory/allocator/destroy).
