### PR TITLE
locks/spinlock: "pause" inline asm should specify "memory" clobber

### DIFF
--- a/locks/oldspinlock.h
+++ b/locks/oldspinlock.h
@@ -82,7 +82,7 @@ extern "C" size_t MyInterlockedExchange (size_t * oldval,
 
 #elif defined(__GNUC__)
 
-#define _MM_PAUSE  { asm (".byte 0xf3; .byte 0x90" : : :); }
+#define _MM_PAUSE  { asm (".byte 0xf3; .byte 0x90" : : : "memory"); }
 
 #else
 

--- a/locks/spinlock-old.h
+++ b/locks/spinlock-old.h
@@ -82,7 +82,7 @@ extern "C" size_t MyInterlockedExchange (size_t * oldval,
 
 #elif defined(__GNUC__)
 
-#define _MM_PAUSE  { asm (".byte 0xf3; .byte 0x90" : : :); }
+#define _MM_PAUSE  { asm (".byte 0xf3; .byte 0x90" : : : "memory"); }
 
 #else
 

--- a/locks/spinlock.h
+++ b/locks/spinlock.h
@@ -78,7 +78,7 @@
 
 #elif defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
 
-#define _MM_PAUSE  { asm (".byte 0xf3; .byte 0x90" : : :); }
+#define _MM_PAUSE  { asm (".byte 0xf3; .byte 0x90" : : : "memory"); }
 
 #else
 


### PR DESCRIPTION
As specified on https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html :

    The "memory" clobber tells the compiler that the assembly code
    performs memory reads or writes to items other than those listed
    in the input and output operands (for example, accessing the
    memory pointed to by one of the input parameters). To ensure
    memory contains correct values, GCC may need to flush specific
    register values to memory before executing the asm. Further, the
    compiler does not assume that any values read from memory before
    an asm remain unchanged after that asm; it reloads them as
    needed. Using the "memory" clobber effectively forms a read/write
    memory barrier for the compiler.

Without this GCC or Clang could reorder reads/writes around the pause.
This clobber is in some stack overflow examples, and also in musl:
http://git.musl-libc.org/cgit/musl/tree/arch/x86_64/atomic.h#n89