### PR TITLE
linux/clang4 fixes

### DIFF
--- a/heaps/debug/sanitycheckheap.h
+++ b/heaps/debug/sanitycheckheap.h
@@ -27,7 +27,7 @@ namespace HL {
     /// This approach lets us use SanityCheckHeaps when we're replacing malloc.
 
     // The objects are pairs, mapping void * pointers to sizes.
-    typedef std::pair<const void *, size_t> objType;
+    typedef std::pair<const intptr_t, size_t> objType;
 
     // The heap is a simple freelist heap.
     typedef HL::FreelistHeap<HL::ZoneHeap<HL::MmapHeap, 16384> > heapType;
@@ -35,10 +35,10 @@ namespace HL {
     // And we wrap it up so it can be used as an STL allocator.
     typedef HL::STLAllocator<objType, heapType> localAllocator;
 
-    typedef std::less<void *> localComparator;
+    typedef std::less<intptr_t> localComparator;
 
     /// A map of pointers to objects and their allocated sizes.
-    typedef std::map<void *, size_t, localComparator, localAllocator> mapType;
+    typedef std::map<intptr_t, size_t, localComparator, localAllocator> mapType;
 
     /// A freed object has a special size, -1.
     enum { FREED = -1 };
@@ -63,11 +63,11 @@ namespace HL {
       // Record this object as allocated.
       mapType::iterator i;
       // Look for this object in the map of allocated objects.
-      i = allocatedObjects.find (ptr);
+      i = allocatedObjects.find ((intptr_t)ptr);
       if (i == allocatedObjects.end()) {
         // We didn't find it (this is good).
         // Add the tuple (ptr, sz).
-        allocatedObjects.insert (std::pair<void *, int>(ptr, sz));
+        allocatedObjects.insert (std::pair<intptr_t, int>((intptr_t)ptr, sz));
       } else {
       // We found it.
       // It really should have been freed.
@@ -86,7 +86,7 @@ namespace HL {
     inline void free (void * ptr) {
       // Look for this object in the list of allocated objects.
       mapType::iterator i;
-      i = allocatedObjects.find (ptr);
+      i = allocatedObjects.find ((intptr_t)ptr);
       if (i == allocatedObjects.end()) {
         assert ( FREE_CALLED_ON_OBJECT_I_NEVER_ALLOCATED );
         return;

--- a/wrappers/wrapper.cpp
+++ b/wrappers/wrapper.cpp
@@ -3,21 +3,21 @@
 /*
 
   Heap Layers: An Extensible Memory Allocation Infrastructure
-  
+
   Copyright (C) 2000-2015 by Emery Berger
   http://www.emeryberger.com
   emery@cs.umass.edu
-  
+
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation; either version 2 of the License, or
   (at your option) any later version.
-  
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License
   along with this program; if not, write to the Free Software
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -330,7 +330,7 @@ extern "C"  char * MYCDECL CUSTOM_GETCWD(char * buf, size_t size)
   static getcwdFunction * real_getcwd
     = reinterpret_cast<getcwdFunction *>
     (reinterpret_cast<uintptr_t>(dlsym (RTLD_NEXT, "getcwd")));
-  
+
   if (!buf) {
     if (size == 0) {
       size = PATH_MAX;
@@ -393,7 +393,7 @@ extern "C" struct mallinfo CUSTOM_MALLINFO(void) {
 #define NEW_INCLUDED
 
 void * operator new (size_t sz)
-#if defined(__GNUC__)
+#if defined(_GLIBCXX_THROW)
   _GLIBCXX_THROW (std::bad_alloc)
 #endif
 {
@@ -416,10 +416,10 @@ void operator delete (void * ptr)
 #if !defined(__SUNPRO_CC) || __SUNPRO_CC > 0x420
 void * operator new (size_t sz, const std::nothrow_t&) throw() {
   return CUSTOM_MALLOC(sz);
-} 
+}
 
-void * operator new[] (size_t size) 
-#if defined(__GNUC__)
+void * operator new[] (size_t size)
+#if defined(_GLIBCXX_THROW)
   _GLIBCXX_THROW (std::bad_alloc)
 #endif
 {
@@ -435,11 +435,16 @@ void * operator new[] (size_t sz, const std::nothrow_t&)
   throw()
  {
   return CUSTOM_MALLOC(sz);
-} 
+}
 
 void operator delete[] (void * ptr)
-#if defined(__GNUC__)
+#if defined(_GLIBCXX_USE_NOEXCEPT)
   _GLIBCXX_USE_NOEXCEPT
+#else
+#if defined(__GNUC__)
+  // clang + libcxx on linux
+  _NOEXCEPT
+#endif
 #endif
 {
   CUSTOM_FREE (ptr);


### PR DESCRIPTION
One of each @emeryberger.  The sanitycheckheap one is sort of annoying, but unless you can think of a way to force the static assert not to hit for `void *`, I don't really have other ideas (see commit messages for details).