### PR TITLE
wrapper: check if __cpp_sized_deallocation is defined

### DIFF
--- a/wrappers/wrapper.cpp
+++ b/wrappers/wrapper.cpp
@@ -450,7 +450,7 @@ void operator delete[] (void * ptr)
   CUSTOM_FREE (ptr);
 }
 
-#if __cpp_sized_deallocation >= 201309
+#if defined(__cpp_sized_deallocation) && __cpp_sized_deallocation >= 201309
 
 void operator delete(void * ptr, size_t)
 #if !defined(linux_)


### PR DESCRIPTION
Otherwise I get this error on recent clang:

Heap-Layers/wrappers/wrapper.cpp:453:5: warning: '__cpp_sized_deallocation' is not defined, evaluates to 0 [-Wundef]
    ^