### PR TITLE
debugheap: use intptr_t instead of char * in pointer arithmetic

### DIFF
--- a/heaps/debug/debugheap.h
+++ b/heaps/debug/debugheap.h
@@ -37,7 +37,7 @@ namespace HL {
         ((char *) ptr)[i] = 'A';
       }
       size_t * canaryLocation =
-	(size_t *) ((char *) ptr + realSize - sizeof(size_t));
+	(size_t *) ((intptr_t) ptr + realSize - sizeof(size_t));
       *canaryLocation = (size_t) CANARY;
       return ptr;
     }
@@ -48,7 +48,7 @@ namespace HL {
 	size_t realSize = Super::getSize(ptr);
 	// Check for the canary.
 	size_t * canaryLocation =
-	  (size_t *) ((char *) ptr + realSize - sizeof(size_t));
+	  (size_t *) ((intptr_t) ptr + realSize - sizeof(size_t));
 	size_t storedCanary = *canaryLocation;
 	if (storedCanary != CANARY) {
 	  abort();


### PR DESCRIPTION
This avoids:
```
Heap-Layers/heaps/./debug/debugheap.h:40:2: warning: cast from 'char *' to 'size_t *' (aka 'unsigned long *') increases required alignment from 1 to 8 [-Wcast-align]
        (size_t *) ((char *) ptr + realSize - sizeof(size_t));
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```