### PR TITLE
ExceptionHeap: explit throw lists are deprecated in C++11

### DIFF
--- a/heaps/utility/exceptionheap.h
+++ b/heaps/utility/exceptionheap.h
@@ -29,17 +29,25 @@
 
 #include <new>
 
-//class std::bad_alloc;
+// explicit throw lists are deprecated in C++11 and higher, and GCC
+// complains about them
+#if __cplusplus >= 201103L
+#define HL_THROW_BAD_ALLOC
+#else
+class std::bad_alloc;
+#define HL_THROW_BAD_ALLOC throw (std::bad_alloc)
+#endif
+
 
 namespace HL {
 
   template <class Super>
   class ExceptionHeap : public Super {
   public:
-    inline void * malloc (size_t sz) throw (std::bad_alloc) {
+    inline void * malloc (size_t sz) HL_THROW_BAD_ALLOC {
       void * ptr = Super::malloc (sz);
       if (ptr == NULL) {
-	throw new std::bad_alloc;
+        throw new std::bad_alloc;
       }
       return ptr;
     }


### PR DESCRIPTION
So if we're targeting C++11 or greater, don't list anything.  Is there
a better way to do this, or alternatively should we just remove
throw() @emeryberger?

Reasoning is here:
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3051.html

And some Stack Overflow comments here:
https://stackoverflow.com/questions/13841559/deprecated-throw-list-in-c11