### PR TITLE
Support for Buffered Locked Heap

### DIFF
--- a/heaps/threads/all.h
+++ b/heaps/threads/all.h
@@ -1,3 +1,4 @@
+#include "bufferedlockedheap.h"
 #include "lockedheap.h"
 #include "phothreadheap.h"
 #include "threadheap.h"

--- a/heaps/threads/bufferedlockedheap.h
+++ b/heaps/threads/bufferedlockedheap.h
@@ -1,0 +1,91 @@
+#ifndef HL_BUFFEREDLOCKEDHEAP_H
+#define HL_BUFFEREDLOCKEDHEAP_H
+
+#include <cstddef>
+#include "utility/guard.h"
+
+namespace HL {
+
+  template <int Size, class LockType, class Super>
+  class BufferedLockedHeap : public Super {
+  public:
+
+    enum { Alignment = Super::Alignment };
+
+    void * malloc (size_t sz) {
+      Guard<LockType> l (theLock);
+      void *ptr = Super::malloc (sz);
+      if (ptr != NULL) {
+        return ptr;
+      }
+      // Emptying the freeBuffer and trying again
+      emptyFreeBuffer();
+      return Super::malloc (sz);
+    }
+
+    void free (void *ptr) {
+      if (freeIndex == Size) {
+        Guard<LockType> l (theLock);
+        emptyFreeBuffer();
+      }
+      if (freeBuffer == NULL) {
+        init();
+      }
+      freeBuffer[freeIndex] = ptr;
+      freeIndex++;
+    }
+
+    inline size_t getSize (void * ptr) const {
+      Guard<LockType> l (theLock);
+      return Super::getSize (ptr);
+    }
+
+    inline size_t getSize (void * ptr) {
+      Guard<LockType> l (theLock);
+      return Super::getSize (ptr);
+    }
+
+    inline void lock (void) {
+      theLock.lock();
+    }
+
+    inline void unlock (void) {
+      theLock.unlock();
+    }
+
+    void clear (void) {
+      Guard<LockType> l (theLock);
+      emptyFreeBuffer();
+      Super::free (freeBuffer);
+    }
+
+  private:
+
+    void init (void) {
+      Guard<LockType> l (theLock);
+      freeBuffer = reinterpret_cast<void **>
+        (Super::malloc (sizeof(void *) * Size));
+      freeIndex = 0;
+    }
+
+    void emptyFreeBuffer (void) {
+      for (int i = 0; i < freeIndex; i++) {
+        Super::free (freeBuffer[i]);
+      }
+      freeIndex = 0;
+    }
+
+    static __thread void **freeBuffer;
+    static __thread int freeIndex;
+
+    LockType theLock;
+  };
+
+  template <int Size, class LockType, class Super>
+  __thread void **BufferedLockedHeap<Size, LockType, Super>::freeBuffer = NULL;
+  template <int Size, class LockType, class Super>
+  __thread int BufferedLockedHeap<Size, LockType, Super>::freeIndex = 0;
+
+}
+
+#endif

--- a/heaps/threads/bufferedlockedheap.h
+++ b/heaps/threads/bufferedlockedheap.h
@@ -4,6 +4,25 @@
 #include <mutex>
 #include <cstddef>
 
+#ifndef thread_local
+# if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
+#  define thread_local _Thread_local
+# elif defined _WIN32 && ( \
+       defined _MSC_VER || \
+       defined __ICL || \
+       defined __DMC__ || \
+       defined __BORLANDC__ )
+#  define thread_local __declspec(thread) 
+/* note that ICC (linux) and Clang are covered by __GNUC__ */
+# elif defined __GNUC__ || \
+       defined __SUNPRO_C || \
+       defined __xlC__
+#  define thread_local __thread
+# else
+#  error "Cannot define thread_local"
+# endif
+#endif
+
 namespace HL {
 
   template <int Size, class LockType, class Super>
@@ -75,16 +94,16 @@ namespace HL {
       freeIndex = 0;
     }
 
-    static __thread void **freeBuffer;
-    static __thread int freeIndex;
+    static thread_local void **freeBuffer;
+    static thread_local int freeIndex;
 
     LockType thelock;
   };
 
   template <int Size, class LockType, class Super>
-  __thread void **BufferedLockedHeap<Size, LockType, Super>::freeBuffer = NULL;
+  thread_local void **BufferedLockedHeap<Size, LockType, Super>::freeBuffer = NULL;
   template <int Size, class LockType, class Super>
-  __thread int BufferedLockedHeap<Size, LockType, Super>::freeIndex = 0;
+  thread_local int BufferedLockedHeap<Size, LockType, Super>::freeIndex = 0;
 
 }
 


### PR DESCRIPTION
This provides support for Buffered Locked Heap. Chunks ready to be released are buffered and released in one go. This prevents repeated locking while freeing each chunk individually.