### PR TITLE
CUSTOM_MEMALIGN - match internal free call to alloc

### DIFF
--- a/wrappers/wrapper.cpp
+++ b/wrappers/wrapper.cpp
@@ -213,7 +213,7 @@ extern "C" void * MYCDECL CUSTOM_MEMALIGN (size_t alignment, size_t size)
       return ptr;
     }
     // It was not aligned as requested: free the object and allocate a big one.
-    CUSTOM_FREE(ptr);
+    xxfree(ptr);
     ptr = xxmalloc (size + 2 * alignment);
     void * alignedPtr = (void *) (((size_t) ptr + alignment - 1) & ~(alignment - 1));
     return alignedPtr;


### PR DESCRIPTION
During a call to CUSTOM_MEMALIGN(), if the first allocation try fails to
"happen to be" properly allocated, then it is freed and explicitely
reallocated.
This free() call did not match the xxmalloc() one: CUSTOM_FREE() instead
of xxfree()

This causes a crash when calling gdb for example:
  LD_PRELOAD=~/Hoard/src/libhoard.so gdb --args ls