### PR TITLE
README.md: Fix syntax of the BibTex block

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ opportunities.
 
 To reference Heap Layers in an academic paper, please cite as follows:
 
-```@inproceedings{DBLP:conf/pldi/BergerZM01,
+```
+@inproceedings{DBLP:conf/pldi/BergerZM01,
   author    = {Emery D. Berger and
                Benjamin G. Zorn and
                Kathryn S. McKinley},


### PR DESCRIPTION
In markdown “fenced code blocks”, the text on the same line as the opening backticks is a language setting (for syntax colouring) not literal text that's part of the code block.