### PR TITLE
mallocheap: on linux, use <malloc.h> for malloc_usable_size

### DIFF
--- a/heaps/top/mallocheap.h
+++ b/heaps/top/mallocheap.h
@@ -33,6 +33,8 @@
 extern "C" size_t malloc_usable_size (void *);
 #elif defined(__APPLE__)
 #include <malloc/malloc.h>
+#elif defined(__linux__)
+#include <malloc.h>
 #else
 extern "C" size_t malloc_usable_size (void *) throw ();
 #endif

--- a/heaps/utility/localmallocheap.h
+++ b/heaps/utility/localmallocheap.h
@@ -38,6 +38,10 @@
 
 #if defined(__SVR4)
 extern "C" size_t malloc_usable_size (void *);
+#elif defined(__APPLE__)
+#include <malloc/malloc.h>
+#elif defined(__linux__)
+#include <malloc.h>
 #else
 extern "C" size_t malloc_usable_size (void *) throw ();
 #endif

--- a/utility/tprintf.h
+++ b/utility/tprintf.h
@@ -127,7 +127,7 @@ namespace tprintf {
     }
   }
 
-};
+}
 
 
 #endif

--- a/utility/tprintf.h
+++ b/utility/tprintf.h
@@ -78,30 +78,30 @@ namespace tprintf {
   inline void writeval(double n) {
     char buf[MAXBUF];
     int len = ftoa(buf, n);
-    write(FD, buf, len);
+    auto _ __attribute__((unused)) = write(FD, buf, len);
   }
   
   inline void writeval(const char * str) {
-    write(FD, str, strlen(str));
+    auto _ __attribute__((unused)) = write(FD, str, strlen(str));
   }
 
   inline void writeval(const char c) {
     char buf[1];
     buf[0] = c;
-    write(FD, buf, 1);
+    auto _ __attribute__((unused)) = write(FD, buf, 1);
   }
 
   inline void writeval(uint64_t n) {
     char buf[MAXBUF];
     int len = itoa(buf, n);
-    write(FD, buf, len);
+    auto _ __attribute__((unused)) = write(FD, buf, len);
   }
 
   template <class T>
   inline void writeval(T n) {
     char buf[MAXBUF];
     int len = itoa(buf, n);
-    write(FD, buf, len);
+    auto _ __attribute__((unused)) = write(FD, buf, len);
   }
 
   inline void tprintf(const char* format) // base function


### PR DESCRIPTION
this should enable building Mesh (+ other allocators!) on Linux with musl llbc