### PR TITLE
include "heaplayers.h", so that heaplayers works better with -iquote

### DIFF
--- a/heaplayers
+++ b/heaplayers
@@ -1,1 +1,1 @@
-#include <heaplayers.h>
+#include "heaplayers.h"

--- a/heaps/combining/hybridheap.h
+++ b/heaps/combining/hybridheap.h
@@ -31,7 +31,7 @@
 
 #include <assert.h>
 
-#include <heaplayers.h>
+#include "heaplayers.h"
 
 /**
  * @class HybridHeap

--- a/heaps/combining/segheap.h
+++ b/heaps/combining/segheap.h
@@ -57,7 +57,8 @@
  **/
 
 #include <assert.h>
-#include <utility/gcd.h>
+
+#include "utility/gcd.h"
 
 namespace HL {
 

--- a/heaps/special/xallocheap.h
+++ b/heaps/special/xallocheap.h
@@ -28,7 +28,8 @@
 #define HL_XALLOCHEAP_H
 
 #include <cstddef>
-#include <utility/align.h>
+
+#include "utility/align.h"
 
 namespace HL {
 


### PR DESCRIPTION
This will enable even simpler/nicer bazel integration, but should have
no other effect.

Updates #25