### PR TITLE
Fixes segfault in scalene and missing destructor

### DIFF
--- a/heaps/threads/threadspecificheap.h
+++ b/heaps/threads/threadspecificheap.h
@@ -53,7 +53,9 @@ namespace HL {
     }
 
     inline void free (void * ptr) {
-      getHeap()->free (ptr);
+      PerThreadHeap * heap =
+	(PerThreadHeap *) pthread_getspecific (getHeapKey());
+      if (heap) heap->free (ptr);
     }
 
     inline size_t getSize (void * ptr) {
@@ -81,7 +83,9 @@ namespace HL {
 
     static void deleteHeap (void *) {
       PerThreadHeap * heap = getHeap();
+      heap->~PerThreadHeap();
       HL::MmapWrapper::unmap (heap, sizeof(PerThreadHeap));
+      pthread_setspecific (getHeapKey(), 0);
     }
 
     // Access the given heap.


### PR DESCRIPTION
If another component registers a TSD destructor invoking `free()` and `ThreadSpecificHeap` is used to
override `free`/`malloc`/..., such as in [scalene](https://github.com/emeryberger/scalene), it's possible
(and, in my testing, usually the case) that when a thread exits, the heap may be destroyed before such
a destructor, leading to a seg fault.

Here is a test that reproduces it:
```
#include <pthread.h>
#include <cstdlib>
#include <thread>

static pthread_key_t key;

static void destructor(void* m) {
   free(m);
}

static void test_thread() {
    pthread_setspecific(key, malloc(100));
}

int
main(int argc, char* argv[]) {
    pthread_key_create(&key, destructor);
    std::thread t(test_thread);
    t.join();

    return 0;
}
```
You reproduce it by running:
```
g++ -std=c++17 -o tsd-test tsd-test.cpp -lpthread
LD_PRELOAD=./libscalene.so ./tsd-test
```

This happened for me using `scalene` on a python script that uses TensorFlow.  I'll open it there
as an issue (to document it) and link.