### PR TITLE
Added locking around memalign, so it is locked, too, if the super heap supports it.

### DIFF
--- a/heaps/threads/lockedheap.h
+++ b/heaps/threads/lockedheap.h
@@ -44,6 +44,11 @@ namespace HL {
       return Super::free (ptr, sz);
     }
 
+    inline void * memalign (size_t alignment, size_t sz) {
+      std::lock_guard<LockType> l (thelock);
+      return Super::memalign (alignment, sz);
+    }
+
     inline size_t getSize (void * ptr) const {
       std::lock_guard<LockType> l (thelock);
       return Super::getSize (ptr);


### PR DESCRIPTION
This is to enable using `LockedHeap` in https://github.com/jaltmayerpizzorno/scalene/tree/f202103_nextheap_init