### PR TITLE
Added support for redefining realloc

### DIFF
--- a/heaplayers.h
+++ b/heaplayers.h
@@ -93,6 +93,10 @@ namespace HL {}
 #pragma warning( disable:4786 4512 )
 #endif
 
+#if !defined(HL_USE_XXREALLOC)
+#define HL_USE_XXREALLOC 0
+#endif
+
 #include "utility/all.h"
 #include "heaps/all.h"
 #include "locks/all.h"

--- a/heaps/threads/threadspecificheap.h
+++ b/heaps/threads/threadspecificheap.h
@@ -77,6 +77,14 @@ namespace HL {
       }
       return heap->malloc(sz);
     }
+    #if HL_USE_XXREALLOC
+    inline void * realloc(void* ptr, size_t sz) {
+      if (heap == nullptr) {
+        heap = new (heapbuf) PerThreadHeap();
+      }
+      return heap->realloc(ptr, sz);
+    }
+    #endif
 
     inline void free(void * ptr) {
       if (heap == nullptr) {

--- a/wrappers/heapredirect.h
+++ b/wrappers/heapredirect.h
@@ -139,6 +139,14 @@ class HeapWrapper {
     return ptr;
   }
 
+  #if HL_USE_XXREALLOC
+  static inline void* realloc(void * ptr, size_t sz) {
+    auto buf = getHeap<CustomHeapType>()->realloc(ptr, sz);
+    assert(isValid(buf));
+    return buf;
+  }
+  #endif
+
   static inline bool isValid(void * ptr) {
 #if !defined(__GLIBC__)
     (void) ptr;
@@ -204,6 +212,38 @@ class HeapWrapper {
 
 } // namespace
 
+#if HL_USE_XXREALLOC
+#define HEAP_REDIRECT(CustomHeap, staticSize)\
+  typedef HL::HeapWrapper<CustomHeap, staticSize> TheHeapWrapper;\
+  extern "C" {\
+    ATTRIBUTE_EXPORT void *xxmalloc(size_t sz) {\
+      return TheHeapWrapper::malloc(sz);\
+    }\
+    \
+    ATTRIBUTE_EXPORT void xxfree(void *ptr) {\
+      TheHeapWrapper::free(ptr);\
+    }\
+    \
+    ATTRIBUTE_EXPORT void *xxmemalign(size_t alignment, size_t sz) {\
+      return TheHeapWrapper::memalign(alignment, sz);\
+    }\
+    \
+    ATTRIBUTE_EXPORT size_t xxmalloc_usable_size(void *ptr) {\
+      return TheHeapWrapper::getSize(ptr);	\
+    }\
+    \
+    ATTRIBUTE_EXPORT void xxmalloc_lock() {\
+      TheHeapWrapper::xxmalloc_lock();\
+    }\
+    \
+    ATTRIBUTE_EXPORT void xxmalloc_unlock() {\
+      TheHeapWrapper::xxmalloc_unlock();\
+    }\
+    ATTRIBUTE_EXPORT void* xxrealloc(void * ptr, size_t sz) {\
+      return TheHeapWrapper::realloc(ptr, sz); \
+    }\
+  }
+#else
 #define HEAP_REDIRECT(CustomHeap, staticSize)\
   typedef HL::HeapWrapper<CustomHeap, staticSize> TheHeapWrapper;\
   extern "C" {\

--- a/wrappers/wrapper.cpp
+++ b/wrappers/wrapper.cpp
@@ -32,7 +32,9 @@ extern "C" {
   void * xxmalloc (size_t);
   void   xxfree (void *);
   void * xxmemalign(size_t, size_t);
-  
+  #if HL_USE_XXREALLOC
+  void * xxrealloc(void *, size_t);
+  #endif
   // Takes a pointer and returns how much space it holds.
   size_t xxmalloc_usable_size (void *);
 
@@ -257,6 +259,10 @@ extern "C" size_t MYCDECL CUSTOM_GOODSIZE (size_t sz) {
 
 extern "C" void * MYCDECL CUSTOM_REALLOC (void * ptr, size_t sz)
 {
+#if HL_USE_XXREALLOC
+  void* buf = xxrealloc(ptr, sz);
+  return buf;
+#else
   if (!ptr) {
     ptr = xxmalloc (sz);
     return ptr;
@@ -295,6 +301,7 @@ extern "C" void * MYCDECL CUSTOM_REALLOC (void * ptr, size_t sz)
 
   // Return a pointer to the new one.
   return buf;
+#endif
 }
 
 extern "C" void * MYCDECL CUSTOM_REALLOCARRAY (void * ptr, size_t sz1, size_t sz2)


### PR DESCRIPTION
Add compiler macro, `HL_USE_XXREALLOC`, which can be written to in order to override Heap-Layers' provided `realloc` without interfering with existing dependent builds. To support this, added new variation of `HEAP_REDIRECT` macro and added function in `HeapWrapper`. 