### PR TITLE
Removed a check for `isValid` in `register_malloc`

### DIFF
--- a/heaps/threads/threadspecificheap.h
+++ b/heaps/threads/threadspecificheap.h
@@ -140,6 +140,11 @@ namespace HL {
     inline void * malloc (size_t sz) {
       return getHeap()->malloc (sz);
     }
+    #if HL_USE_XXREALLOC
+    inline void * realloc(void* ptr, size_t sz) {
+      return getHeap()->realloc(ptr, sz);
+    }
+    #endif
 
     inline void free (void * ptr) {
       getHeap()->free (ptr);

--- a/wrappers/heapredirect.h
+++ b/wrappers/heapredirect.h
@@ -197,9 +197,7 @@ class HeapWrapper {
 
   // For use with sampling allocation from https://github.com/plasma-umass/scalene
   static inline void register_malloc(size_t sz, void * ptr) {
-    if (isValid(ptr)) {
-      getHeap<CustomHeapType>()->register_malloc(sz, ptr);
-    }
+    getHeap<CustomHeapType>()->register_malloc(sz, ptr);
   }
 
   static inline void register_free(size_t sz, void * ptr) {


### PR DESCRIPTION
Since, in practice, we frequently call `register_malloc` on things that the Python allocator allocated and `isValid` checks whether something is allocated by system malloc, this check frequently fails.