### PR TITLE
Some fixes for Darwin

### DIFF
--- a/locks/oldspinlock.h
+++ b/locks/oldspinlock.h
@@ -67,6 +67,11 @@ extern "C" size_t MyInterlockedExchange (size_t * oldval,
 // hyperthreading.  See
 // http://www.usenix.org/events/wiess02/tech/full_papers/nakajima/nakajima.pdf
 // for discussion.
+// On PowerPC `or Rx Rx Rx` is a nop, but may have extra effects like setting
+// priority etc. `or r27 r27 r27` is an equivanent of "pause", and in ISA 2.06+
+// has an alias `yield`. For examples of usage, see Boost libfiber, catch2, seqan3.
+// https://stackoverflow.com/questions/5425506/equivalent-of-x86-pause-instruction-for-ppc
+// https://utcc.utoronto.ca/~cks/space/blog/tech/PowerPCInstructionOddity?showcomments
 
 #define _MM_PAUSE  {__asm{_emit 0xf3};__asm {_emit 0x90}}
 #include <windows.h>

--- a/locks/oldspinlock.h
+++ b/locks/oldspinlock.h
@@ -71,9 +71,13 @@ extern "C" size_t MyInterlockedExchange (size_t * oldval,
 #define _MM_PAUSE  {__asm{_emit 0xf3};__asm {_emit 0x90}}
 #include <windows.h>
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
 
 #define _MM_PAUSE  { asm (".byte 0xf3; .byte 0x90" : : : "memory"); }
+
+#elif defined(__POWERPC__)
+
+#define _MM_PAUSE  { __asm__ volatile ("or r27,r27,r27"); }
 
 #else
 
@@ -221,7 +225,7 @@ HL::SpinLockType::MyInterlockedExchange (size_t * oldval,
 		: "m" (*oldval), "0" (newval)
 		: "memory");
 
-#elif defined(__ppc) || defined(__powerpc__) || defined(PPC)
+#elif defined(__ppc) || defined(__powerpc__) || defined(PPC) || defined(__POWERPC__)
   // PPC assembly contributed by Maged Michael.
   int ret; 
   asm volatile ( 

--- a/locks/spinlock-old.h
+++ b/locks/spinlock-old.h
@@ -67,6 +67,11 @@ extern "C" size_t MyInterlockedExchange (size_t * oldval,
 // hyperthreading.  See
 // http://www.usenix.org/events/wiess02/tech/full_papers/nakajima/nakajima.pdf
 // for discussion.
+// On PowerPC `or Rx Rx Rx` is a nop, but may have extra effects like setting
+// priority etc. `or r27 r27 r27` is an equivanent of "pause", and in ISA 2.06+
+// has an alias `yield`. For examples of usage, see Boost libfiber, catch2, seqan3.
+// https://stackoverflow.com/questions/5425506/equivalent-of-x86-pause-instruction-for-ppc
+// https://utcc.utoronto.ca/~cks/space/blog/tech/PowerPCInstructionOddity?showcomments
 
 #define _MM_PAUSE  {__asm{_emit 0xf3};__asm {_emit 0x90}}
 #include <windows.h>

--- a/locks/spinlock-old.h
+++ b/locks/spinlock-old.h
@@ -71,9 +71,13 @@ extern "C" size_t MyInterlockedExchange (size_t * oldval,
 #define _MM_PAUSE  {__asm{_emit 0xf3};__asm {_emit 0x90}}
 #include <windows.h>
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
 
 #define _MM_PAUSE  { asm (".byte 0xf3; .byte 0x90" : : : "memory"); }
+
+#elif defined(__POWERPC__)
+
+#define _MM_PAUSE  { __asm__ volatile ("or r27,r27,r27"); }
 
 #else
 
@@ -221,7 +225,7 @@ HL::SpinLockType::MyInterlockedExchange (size_t * oldval,
 		: "m" (*oldval), "0" (newval)
 		: "memory");
 
-#elif defined(__ppc) || defined(__powerpc__) || defined(PPC)
+#elif defined(__ppc) || defined(__powerpc__) || defined(PPC) || defined(__POWERPC__)
   // PPC assembly contributed by Maged Michael.
   int ret; 
   asm volatile ( 

--- a/wrappers/macwrapper.cpp
+++ b/wrappers/macwrapper.cpp
@@ -11,6 +11,8 @@
 #error "This file is for use on Mac OS only."
 #endif
 
+#include <AvailabilityMacros.h>
+
 #include <cstdlib>
 using namespace std;
 
@@ -555,8 +557,10 @@ static bool initializeZone(malloc_zone_t& zone) {
   zone.introspect   = NULL;
   zone.version      = 8;
   zone.memalign     = replace_malloc_zone_memalign;
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__POWERPC__)
   zone.free_definite_size = replace_malloc_zone_free_definite_size;
   zone.pressure_relief = NULL;
+#endif
   return true;
 }
 #else

--- a/wrappers/mallocinfo.h
+++ b/wrappers/mallocinfo.h
@@ -27,7 +27,7 @@ namespace HL {
     // Prevent integer overflows by restricting allocation size (usually 2GB).
     enum { MaxSize = UINT_MAX / 2 };
 
-#if defined(__LP64__) || defined(_LP64) || defined(__APPLE__) || defined(_WIN64) || defined(__x86_64__)
+#if defined(__LP64__) || defined(_LP64) || (defined(__APPLE__) && !(defined(__i386__) || defined(__ppc__)))  || defined(_WIN64) || defined(__x86_64__)
     enum { MinSize = 16UL };
     enum { Alignment = 16UL };
 #else


### PR DESCRIPTION
Fixes to malloc_zone and alignments are required. Fixes to old spinlock versions perhaps are not (as long as those are unused), but arguably still desirable.

P. S. Not entirely sure if omission of Darwin PPC macros was intentional (which would imply a preference to `libkern` implementation over pure assembler) or not (which seems quite likely, since many people think `__powerpc__` is some kind of universal define – it is not).