### PR TITLE
added HeaderHeap and re-implemented SizeHeap

### DIFF
--- a/heaps/objectrep/all.h
+++ b/heaps/objectrep/all.h
@@ -2,5 +2,4 @@
 #include "coalesceableheap.h"
 #include "sizeheap.h"
 #include "sizeownerheap.h"
-
-
+#include "headerheap.h"

--- a/heaps/objectrep/headerheap.h
+++ b/heaps/objectrep/headerheap.h
@@ -1,0 +1,57 @@
+/* -*- C++ -*- */
+
+/*
+
+  Heap Layers: An Extensible Memory Allocation Infrastructure
+  
+  Copyright (C) 2000-2020 by Emery Berger
+  http://www.emeryberger.com
+  emery@cs.umass.edu
+  
+  Heap Layers is distributed under the terms of the Apache 2.0 license.
+
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+
+*/
+
+#ifndef HL_HEADERHEAP_H
+#define HL_HEADERHEAP_H
+
+/**
+ * @class HeaderHeap
+ * @brief Generic header heap. User provides only the header struct and function to set the header.
+ * @author André Costa
+ */
+
+#include <assert.h>
+
+namespace HL {
+
+  template <class SuperHeap, class headerObject,
+    void (*headerFunction)(headerObject*, size_t sz, void *)>
+  class HeaderHeap : public SuperHeap {
+    public:
+      ~HeaderHeap () {}
+
+      enum {Alignment = gcd<(int)SuperHeap::Alignment,(int)sizeof(headerObject)>::value};
+
+      inline void * malloc (size_t sz) {
+        headerObject* headerObjectPtr = (headerObject*) SuperHeap::malloc(sz + sizeof(headerObject));
+        void *ptr = (void *) ((uintptr_t)ptr + sizeof(headerObject)); //ptr that "user" heap will see
+        headerFunction(headerObjectPtr, sz, ptr);
+        return (void *) (headerObjectPtr + 1);
+      }
+
+      inline void free (void * ptr) {
+	      SuperHeap::free (getHeader(ptr));
+      }
+
+      inline static headerObject* getHeader(const void * ptr) {
+        return (headerObject*) ((uintptr_t)ptr - sizeof(headerObject));
+      }
+  };
+
+} //namespace HL
+
+#endif


### PR DESCRIPTION
*Description of changes:*
Added HeaderHeap to make it easier to implement Header-based Heaps.
HeaderHeap takes a struct and and an initialization function. It  stores that struct in the first bytes of the allocation, and intializes it by calling the function.
As an example, I re-implemented SizeHeap with HeaderHeap.

Use-case: it just makes it easier to implement Heaps that use headers. I needed to implement one and HeaderHeap made it easier and less repetitive.

PS: I attempted to add the magic number checking to HeaderHeap itself, but it just made the code overly complicated. I feel it is best to keep it something that the user Heap should implement.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
