### PR TITLE
Add HeaderHeap, CI workflow, and fix C23 free_sized linking

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,143 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  # ── Kingsley example (lives in this repo) ──────────────────────────
+  kingsley:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: |
+          cd examples/kingsley
+          mkdir -p build && cd build
+          cmake ..
+
+      - name: Build
+        run: cmake --build examples/kingsley/build --parallel
+
+      - name: Verify library
+        run: |
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            ls -la examples/kingsley/build/libkingsley.dylib
+          else
+            ls -la examples/kingsley/build/libkingsley.so
+          fi
+
+      - name: Smoke test (Linux)
+        if: runner.os == 'Linux'
+        run: LD_PRELOAD=./examples/kingsley/build/libkingsley.so ls /tmp
+
+  # ── DieHard (external repo, Linux + macOS) ─────────────────────────
+  diehard:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: heap-layers
+
+      - name: Clone DieHard
+        run: git clone --depth 1 https://github.com/emeryberger/DieHard.git
+
+      - name: Configure
+        run: |
+          cd DieHard
+          mkdir -p build && cd build
+          cmake \
+            "-DFETCHCONTENT_SOURCE_DIR_HEAP-LAYERS=${{ github.workspace }}/heap-layers" \
+            -DBUILD_TESTS=ON \
+            ..
+
+      - name: Build
+        run: cmake --build DieHard/build --parallel
+
+      - name: Run tests (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          cd DieHard
+          ./build/tests/test_globalfreepool
+          LD_PRELOAD=./build/libdiehard.so ./build/tests/test_remote_free
+          LD_PRELOAD=./build/libdiehard.so ./build/tests/test_doublefree
+          LD_PRELOAD=./build/libdiehard.so ./build/tests/test_invalidfree
+          LD_PRELOAD=./build/libdiehard.so ./build/tests/threadtest 2 10 1000 0 8
+
+      - name: Run tests (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          cd DieHard
+          ./build/tests/test_globalfreepool
+          DYLD_INSERT_LIBRARIES=./build/libdiehard.dylib ./build/tests/test_remote_free
+          DYLD_INSERT_LIBRARIES=./build/libdiehard.dylib ./build/tests/test_doublefree
+          DYLD_INSERT_LIBRARIES=./build/libdiehard.dylib ./build/tests/test_invalidfree
+          DYLD_INSERT_LIBRARIES=./build/libdiehard.dylib ./build/tests/threadtest 2 10 1000 0 8
+
+  # ── Hoard (external repo, Linux + macOS + Windows) ─────────────────
+  hoard:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: heap-layers
+
+      - name: Clone Hoard
+        run: git clone --depth 1 https://github.com/emeryberger/Hoard.git
+
+      - name: Configure (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd Hoard
+          mkdir -p build && cd build
+          cmake \
+            "-DFETCHCONTENT_SOURCE_DIR_HEAP-LAYERS=${{ github.workspace }}/heap-layers" \
+            ${{ runner.os == 'macOS' && '-DCMAKE_OSX_ARCHITECTURES=arm64' || '' }} \
+            ..
+
+      - name: Configure (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          cd Hoard
+          mkdir build
+          cd build
+          cmake "-DFETCHCONTENT_SOURCE_DIR_HEAP-LAYERS=${{ github.workspace }}/heap-layers" ..
+
+      - name: Build (Unix)
+        if: runner.os != 'Windows'
+        run: cmake --build Hoard/build --parallel
+
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        run: cmake --build Hoard/build --config Release --parallel
+
+      - name: Verify library (Linux)
+        if: runner.os == 'Linux'
+        run: ls -la Hoard/build/libhoard.so
+
+      - name: Verify library (macOS)
+        if: runner.os == 'macOS'
+        run: ls -la Hoard/build/libhoard.dylib
+
+      - name: Verify library (Windows)
+        if: runner.os == 'Windows'
+        run: dir Hoard\build\Release\hoard.dll
+
+      - name: Smoke test (Linux)
+        if: runner.os == 'Linux'
+        run: LD_PRELOAD=./Hoard/build/libhoard.so ls /tmp

--- a/examples/kingsley/libkingsley.cpp
+++ b/examples/kingsley/libkingsley.cpp
@@ -67,6 +67,14 @@ extern "C" {
     getCustomHeap()->free (ptr);
   }
 
+  void xxfree_sized (void * ptr, size_t) {
+    getCustomHeap()->free (ptr);
+  }
+
+  void xxfree_aligned_sized (void * ptr, size_t, size_t) {
+    getCustomHeap()->free (ptr);
+  }
+
   void * xxmemalign(size_t alignment, size_t sz) {
     return generic_xxmemalign(alignment, sz);
   }

--- a/heaps/objectrep/all.h
+++ b/heaps/objectrep/all.h
@@ -1,5 +1,6 @@
 #include "addheap.h"
 #include "coalesceableheap.h"
+#include "headerheap.h"
 #include "sizeheap.h"
 #include "sizeownerheap.h"
 

--- a/heaps/objectrep/headerheap.h
+++ b/heaps/objectrep/headerheap.h
@@ -1,0 +1,60 @@
+/* -*- C++ -*- */
+
+/*
+
+  Heap Layers: An Extensible Memory Allocation Infrastructure
+
+  Copyright (C) 2000-2024 by Emery Berger
+  http://www.emeryberger.com
+  emery@cs.umass.edu
+
+  Heap Layers is distributed under the terms of the Apache 2.0 license.
+
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+
+*/
+
+#ifndef HL_HEADERHEAP_H
+#define HL_HEADERHEAP_H
+
+/**
+ * @file headerheap.h
+ * @brief A generic heap layer that prepends a header to each allocation.
+ *
+ * HeaderHeap reserves space for a Header object before each allocation
+ * and provides getHeader() to recover it from a user pointer. Subclasses
+ * override malloc/free to initialize and validate the header.
+ *
+ * Compare to AddHeap, which reserves space using lcm-based sizing
+ * but does not provide getHeader() or initialization hooks.
+ */
+
+#include "utility/gcd.h"
+
+namespace HL {
+
+  template <class Header, class SuperHeap>
+  class HeaderHeap : public SuperHeap {
+  public:
+
+    enum { Alignment = gcd<(int) SuperHeap::Alignment,
+	   (int) sizeof(Header)>::value };
+
+    inline void * malloc (size_t sz) {
+      Header * p = (Header *) SuperHeap::malloc (sz + sizeof(Header));
+      return (void *) (p + 1);
+    }
+
+    inline void free (void * ptr) {
+      SuperHeap::free (getHeader(ptr));
+    }
+
+    inline static Header * getHeader (const void * ptr) {
+      return ((Header *) ptr - 1);
+    }
+  };
+
+}
+
+#endif

--- a/heaps/objectrep/sizeheap.h
+++ b/heaps/objectrep/sizeheap.h
@@ -3,11 +3,11 @@
 /*
 
   Heap Layers: An Extensible Memory Allocation Infrastructure
-  
-  Copyright (C) 2000-2020 by Emery Berger
+
+  Copyright (C) 2000-2024 by Emery Berger
   http://www.emeryberger.com
   emery@cs.umass.edu
-  
+
   Heap Layers is distributed under the terms of the Apache 2.0 license.
 
   You may obtain a copy of the License at
@@ -20,59 +20,59 @@
 
 /**
  * @file sizeheap.h
- * @brief Contains UseSizeHeap and SizeHeap.
+ * @brief Contains SizeHeap.
  */
 
 #include <assert.h>
 
-#include "wrappers/mallocinfo.h"
-#include "heaps/objectrep/addheap.h"
-#include "utility/gcd.h"
+#include "heaps/objectrep/headerheap.h"
 #include "utility/cpp23compat.h"
 
 namespace HL {
 
+  struct SizeHeapHeader {
+    size_t _sz;
+    size_t _magic;
+  };
+
   /**
    * @class SizeHeap
    * @brief Allocates extra room for the size of an object.
+   *
+   * Uses HeaderHeap to prepend a header containing the requested size
+   * and a magic number for validation.
    */
 
   template <class SuperHeap>
-  class SizeHeap : public SuperHeap {
+  class SizeHeap : public HeaderHeap<SizeHeapHeader, SuperHeap> {
 
   private:
-    struct freeObject {
-      size_t _sz;
-      size_t _magic;
-      //      char _buf[HL::MallocInfo::Alignment];
-    };
+
+    using Base = HeaderHeap<SizeHeapHeader, SuperHeap>;
 
     enum { MAGIC_NUMBER = 0xCAFEBABE };
-    
-  public:
 
-    enum { Alignment = gcd<(int) SuperHeap::Alignment,
-	   (int) sizeof(freeObject)>::value };
+  public:
 
     virtual ~SizeHeap (void) {}
 
     inline void * malloc (size_t sz) {
-      freeObject * p = (freeObject *) SuperHeap::malloc (sz + sizeof(freeObject));
-      p->_sz = sz;
-      p->_magic = MAGIC_NUMBER;
-      return (void *) (p + 1);
+      void * ptr = Base::malloc (sz);
+      Base::getHeader(ptr)->_sz = sz;
+      Base::getHeader(ptr)->_magic = MAGIC_NUMBER;
+      return ptr;
     }
 
     inline void free (void * ptr) {
-      if (HL_EXPECT_TRUE(getHeader(ptr)->_magic == MAGIC_NUMBER)) HL_LIKELY {
+      if (HL_EXPECT_TRUE(Base::getHeader(ptr)->_magic == MAGIC_NUMBER)) HL_LIKELY {
 	// Probably one of our objects.
-	SuperHeap::free (getHeader(ptr));
+	Base::free (ptr);
       }
     }
 
     inline static size_t getSize (const void * ptr) {
-      if (HL_EXPECT_TRUE(getHeader(ptr)->_magic == MAGIC_NUMBER)) HL_LIKELY {
-	size_t size = getHeader(ptr)->_sz;
+      if (HL_EXPECT_TRUE(Base::getHeader(ptr)->_magic == MAGIC_NUMBER)) HL_LIKELY {
+	size_t size = Base::getHeader(ptr)->_sz;
 	return size;
       } else HL_UNLIKELY {
 	// Probably not one of our objects.
@@ -83,12 +83,8 @@ namespace HL {
   private:
 
     inline static void setSize (void * ptr, size_t sz) {
-      assert (getHeader(ptr)->_magic == MAGIC_NUMBER);
-      getHeader(ptr)->_sz = sz;
-    }
-
-    inline static freeObject * getHeader (const void * ptr) {
-      return ((freeObject *) ptr - 1);
+      assert (Base::getHeader(ptr)->_magic == MAGIC_NUMBER);
+      Base::getHeader(ptr)->_sz = sz;
     }
 
   };

--- a/wrappers/gnuwrapper.cpp
+++ b/wrappers/gnuwrapper.cpp
@@ -31,7 +31,7 @@
 /*
   To use this library,
   you only need to define the following allocation functions:
-  
+
   - xxmalloc
   - xxfree
   - xxmemalign
@@ -45,6 +45,7 @@
 
 */
 
+#define WEAK(x) __attribute__ ((weak, alias(#x)))
 #ifndef __THROW
 #define __THROW
 #endif
@@ -61,8 +62,11 @@
 #endif
 
 #define ATTRIBUTE_EXPORT __attribute__((visibility("default")))
-#define STRONG_ALIAS(target) __attribute__((alias(#target), visibility("default")))
 
+#define WEAK_REDEF1(type,fname,arg1) ATTRIBUTE_EXPORT type fname(arg1) __THROW WEAK(custom##fname)
+#define WEAK_REDEF2(type,fname,arg1,arg2) ATTRIBUTE_EXPORT type fname(arg1,arg2) __THROW WEAK(custom##fname)
+#define WEAK_REDEF2_NOTHROW(type,fname,arg1,arg2) ATTRIBUTE_EXPORT type fname(arg1,arg2) WEAK(custom##fname)
+#define WEAK_REDEF3(type,fname,arg1,arg2,arg3) ATTRIBUTE_EXPORT type fname(arg1,arg2,arg3) __THROW WEAK(custom##fname)
 
 extern "C" {
   WEAK_REDEF1(void *, malloc, size_t);
@@ -78,28 +82,13 @@ extern "C" {
 #ifdef __USE_XOPEN2K // a work-around for an exception anomaly
   //  WEAK_REDEF2_NOTHROW(void *, aligned_alloc, size_t, size_t);
 #else
-
-#define STRONG_REDEF1(type,fname,arg1) ATTRIBUTE_EXPORT type fname(arg1) __THROW STRONG_ALIAS(custom##fname)
-#define STRONG_REDEF2(type,fname,arg1,arg2) ATTRIBUTE_EXPORT type fname(arg1,arg2) __THROW STRONG_ALIAS(custom##fname)
-#define STRONG_REDEF3(type,fname,arg1,arg2,arg3) ATTRIBUTE_EXPORT type fname(arg1,arg2,arg3) __THROW STRONG_ALIAS(custom##fname)
-
-extern "C" {
-  STRONG_REDEF1(void *, malloc, size_t);
-  STRONG_REDEF1(void, free, void *);
-  STRONG_REDEF1(void, cfree, void *);
-  STRONG_REDEF2(void *, calloc, size_t, size_t);
-  STRONG_REDEF2(void *, realloc, void *, size_t);
-  STRONG_REDEF3(void *, reallocarray, void *, size_t, size_t);
-  STRONG_REDEF2(void *, memalign, size_t, size_t);
-  STRONG_REDEF3(int, posix_memalign, void **, size_t, size_t);
-  STRONG_REDEF2(void *, aligned_alloc, size_t, size_t);
-  STRONG_REDEF1(size_t, malloc_usable_size, void *);
-  STRONG_REDEF1(char *, strdup, const char *);
-  STRONG_REDEF2(char *, strndup, const char *, size_t);
-  STRONG_REDEF1(void *, valloc, size_t);
-  STRONG_REDEF1(void *, pvalloc, size_t);
-}
-
+  WEAK_REDEF2(void *, aligned_alloc, size_t, size_t);
 #endif
+  WEAK_REDEF1(size_t, malloc_usable_size, void *);
+  WEAK_REDEF1(char *, strdup, const char *);
+  WEAK_REDEF2(char *, strndup, const char *, size_t);
+  WEAK_REDEF1(void *, valloc, size_t);
+  WEAK_REDEF1(void *, pvalloc, size_t);
+}
 
 #include "wrapper.cpp"

--- a/wrappers/macwrapper.cpp
+++ b/wrappers/macwrapper.cpp
@@ -56,8 +56,10 @@ extern "C" {
 
   void * xxmalloc (size_t);
   void   xxfree (void *);
-  void   xxfree_sized (void *, size_t);
-  void   xxfree_aligned_sized (void *, size_t, size_t);
+  // Weak defaults so downstream projects that haven't added these yet
+  // (e.g. DieHard, Hoard) still link.  A strong definition wins.
+  __attribute__((weak)) void xxfree_sized (void * ptr, size_t) { xxfree(ptr); }
+  __attribute__((weak)) void xxfree_aligned_sized (void * ptr, size_t, size_t) { xxfree(ptr); }
   void * xxmemalign(size_t, size_t);
 
   // Takes a pointer and returns how much space it holds.


### PR DESCRIPTION
## Summary

- **HeaderHeap**: New generic `HeaderHeap<Header, SuperHeap>` layer that prepends a fixed header to each allocation, with alignment computed via `gcd`. Refactors `SizeHeap` to inherit from it, eliminating duplicated pointer arithmetic while preserving magic-number validation.

- **CI workflow**: `build-and-test.yml` builds and tests three downstream consumers on every push/PR to master:
  | Project | Linux | macOS | Windows |
  |---------|-------|-------|---------|
  | Kingsley (in-repo example) | build + `LD_PRELOAD` smoke test | build + verify | — |
  | DieHard | build + full test suite | build + test suite | — |
  | Hoard | build + `LD_PRELOAD` smoke test | build + verify | build + verify DLL |

  Uses `FETCHCONTENT_SOURCE_DIR_HEAP-LAYERS` to inject the PR's version of Heap-Layers into DieHard and Hoard builds.

- **gnuwrapper.cpp fix**: Restores `WEAK_REDEF` macro definitions that were lost during the C23 `free_sized` merge.

- **macwrapper.cpp weak defaults**: Adds `__attribute__((weak))` fallback implementations of `xxfree_sized` / `xxfree_aligned_sized` (delegating to `xxfree`) so downstream projects that haven't added these yet still link on macOS, where the Mach-O linker requires all symbols resolved at link time.

- **Kingsley example**: Adds `xxfree_sized` / `xxfree_aligned_sized` stubs.

## Test plan

- [x] All 7 CI jobs pass (kingsley linux/macos, diehard linux/macos, hoard linux/macos/windows)
- [x] Scalene builds and passes its full test suite with these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)